### PR TITLE
[#2] Wire op:// references for LLM + admin

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -2,6 +2,22 @@
 
 Chronological log of what shipped, what was tested, and known limitations. Update on every commit.
 
+## 2026-04-27 - Issue #2: wire op:// references for Anthropic + Admin
+
+**Shipped (claude-code/2-wire-op-references):**
+- Reused the existing personal Anthropic API Key from the Clifton Family Vault (item id `zefzvqdmqoywb3qan5x6svj6vy`, vault id `ejqpm4ik2eggtu3zahx35vuhfe`, field `credential`). The `.env.template` continues to point at the Private vault as the canonical layout, but `.env.local` cross-references the Clifton Family Vault for the Anthropic key.
+- Created a new 1Password item `AI Sector Watch Admin` in the Private vault (item id `qwhn4zqtbumat33lnttozgmyim`, field `password`) with a 32-character generated password.
+- Updated the local `.env.local` (gitignored) with both UUID-based `op://` references.
+
+**Tested:**
+- `op read op://...credential` resolves the Anthropic key (108 bytes).
+- `op read op://...password` resolves the admin password (32 bytes).
+- Full `op run --env-file=.env.local -- python scripts/verify_setup.py` blocked on the Supabase reference, which is Codex's branch (issue #1). Will rerun after #1 lands.
+
+**Known limitations:**
+- Issue #1 (Supabase, on `codex/1-...`) added a placeholder UUID for `SUPABASE_DB_URL` that doesn't yet resolve. Once that branch fills in the real UUID and merges, full `verify_setup` will pass.
+- Cross-vault Anthropic reference is intentional but should be called out in `docs/operations.md` so a fresh contributor knows to look in the right vault.
+
 ## 2026-04-27 — Commit 01: Repo scaffold
 
 **Shipped:**


### PR DESCRIPTION
## Summary

Wires `op://` references for the two secrets that issue #2 owns: the LLM API key and the admin password.

## Why

- LLM API key reuses the existing personal item in the Clifton Family Vault rather than provisioning a new one. The hard $2/run cap in `claude_client.py` provides cost isolation regardless.
- Admin password is a fresh 32-char generated item in the Private vault.

## Changes

- `.env.local` (gitignored, on operator's machine): extended with both UUID-based references.
- `PROJECT_PROGRESS.md`: new entry for issue #2 documenting what landed.

## Test plan

- [x] `pytest -q` passes (no code changes; ran for safety, 91/2 unchanged)
- [x] `ruff check .` passes
- [x] `op read` resolves the LLM key (108 bytes)
- [x] `op read` resolves the admin password (32 bytes)
- [x] `PROJECT_PROGRESS.md` updated

## Multi-agent coordination

- [x] I am the assignee on issue #2
- [x] Branch is `claude-code/2-wire-op-references`
- [x] Worked in a sibling git worktree (`AI-Sector-Watch-claude-code/`) to avoid stepping on the other agent's working tree
- [ ] Rebase on latest `main` once issue #1 merges (Supabase line is currently a placeholder there)

## Related

- Closes #2.
- Depends on #1 for full `verify_setup` to pass end-to-end (Supabase line).