### PR TITLE
[#11] Audit cleanup: op --account, dotenv-skip-op, helpers, PROGRESS rule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ What problem does it solve? What does it enable?
 - [ ] `ruff check .` passes
 - [ ] `black --check .` passes
 - [ ] Manual smoke check (describe)
-- [ ] `PROJECT_PROGRESS.md` updated
+- [ ] `PROJECT_PROGRESS.md` updated *if* this is a milestone (closes Now/Next issue, ships public feature, breaks something). Otherwise leave alone.
 
 ## Multi-agent coordination
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,14 +38,14 @@ If two sources of truth disagree, fix the disagreement in the same commit. Don't
 
 These are hard rules. If a task seems to require breaking one, stop and ask.
 
-1. **Never commit secrets.** `.env.local` is gitignored. Only `.env.template` (which holds `op://` references, not values) is in the repo. Run secret-bearing commands via `op run --env-file=.env.local -- <cmd>`.
+1. **Never commit secrets.** `.env.local` is gitignored. Only `.env.template` (which holds `op://` references, not values) is in the repo. Run secret-bearing commands via `op run --account my.1password.com --env-file=.env.local -- <cmd>`.
 2. **Public map only shows verified companies.** `discovery_status = 'verified'` is the gate. Auto-discovered candidates wait in the admin queue at `/Admin`.
 3. **Idempotent operations.** Every upsert keys on a stable hash (URL hash for news, normalised name + country for companies, payload hash for ingest events). Reruns must be safe.
 4. **UTC at storage boundaries.** Local time is for human-facing surfaces only.
 5. **LLM spend cap.** `ANTHROPIC_BUDGET_USD_PER_RUN` (default $2) is enforced in `extraction/claude_client.py`. Don't bypass it. Don't raise it without a reason.
 6. **Type hints everywhere.** `ruff check .` and `black --check .` run in CI.
 7. **No em dashes in user-facing output.** Digest markdown, dashboard copy, popup HTML. Use a colon, comma, or " - " instead. Docstrings are fine.
-8. **Update `PROJECT_PROGRESS.md` in every commit** that ships shipped functionality.
+8. **Update `PROJECT_PROGRESS.md` only for milestones** (closing a Now/Next issue, shipping a public feature, breaking something publicly). For everything else, the PR body is the record. This keeps parallel PRs from serially conflicting on the same file.
 
 ## 4. Stop and ask before
 
@@ -98,7 +98,7 @@ These are hard rules. If a task seems to require breaking one, stop and ask.
 
 1. Append a YAML block to [`data/seed/companies.yaml`](data/seed/companies.yaml). Schema is documented at the top of the file.
 2. `python scripts/seed_companies.py --dry-run` to validate.
-3. `op run --env-file=.env.local -- python scripts/seed_companies.py` to apply (idempotent).
+3. `op run --account my.1password.com --env-file=.env.local -- python scripts/seed_companies.py` to apply (idempotent).
 
 ### Add a sector tag
 
@@ -122,7 +122,7 @@ black --check .
 ### Trigger the weekly pipeline manually
 
 ```bash
-op run --env-file=.env.local -- python scripts/run_weekly_pipeline.py --limit 5
+op run --account my.1password.com --env-file=.env.local -- python scripts/run_weekly_pipeline.py --limit 5
 # or
 gh workflow run weekly.yml -f limit=5
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Before you write code, read:
 - [ ] Python 3.12 venv created (`python3.12 -m venv .venv`).
 - [ ] `pip install -e ".[dashboard,dev]"`.
 - [ ] `pytest -q`, `ruff check .`, `black --check .` all pass.
-- [ ] Your change updates `PROJECT_PROGRESS.md` if it ships functionality.
+- [ ] If your change is a milestone (closes a Now/Next issue, ships a public feature, breaks something), update `PROJECT_PROGRESS.md`. Otherwise the PR body is the record.
 - [ ] Your change has a test or a documented manual smoke check.
 - [ ] No em dashes in user-facing copy (digest, dashboard, popups).
 - [ ] No bare secrets in any committed file.

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ AISW_FORCE_YAML=1 streamlit run dashboard/streamlit_app.py
 Once your Supabase project is provisioned and your 1Password references are wired:
 
 ```bash
-op run --env-file=.env.local -- python scripts/verify_setup.py --apply-schema
-op run --env-file=.env.local -- python scripts/seed_companies.py
-op run --env-file=.env.local -- streamlit run dashboard/streamlit_app.py
+op run --account my.1password.com --env-file=.env.local -- python scripts/verify_setup.py --apply-schema
+op run --account my.1password.com --env-file=.env.local -- python scripts/seed_companies.py
+op run --account my.1password.com --env-file=.env.local -- streamlit run dashboard/streamlit_app.py
 ```
 
 ## Running the pipeline
@@ -168,7 +168,7 @@ op run --env-file=.env.local -- streamlit run dashboard/streamlit_app.py
 Locally, with secrets:
 
 ```bash
-op run --env-file=.env.local -- python scripts/run_weekly_pipeline.py --limit 5
+op run --account my.1password.com --env-file=.env.local -- python scripts/run_weekly_pipeline.py --limit 5
 ```
 
 `--limit N` caps items per source (useful for cheap test runs). `--dry-run` exercises every step except the Supabase writes.
@@ -197,7 +197,7 @@ Append a block to [`data/seed/companies.yaml`](data/seed/companies.yaml) (schema
 
 ```bash
 python scripts/seed_companies.py --dry-run    # validate
-op run --env-file=.env.local -- python scripts/seed_companies.py    # apply
+op run --account my.1password.com --env-file=.env.local -- python scripts/seed_companies.py    # apply
 ```
 
 The seeder is idempotent (upsert by `(name_normalised, country)`).
@@ -231,7 +231,7 @@ Hit the **Admin** page (password-gated). The pipeline writes new candidates as `
 Full detail in [`AGENTS.md`](AGENTS.md). Short version:
 
 - Python 3.12, type hints everywhere, ruff + black configured in `pyproject.toml`.
-- All secrets via 1Password (`op run --env-file=.env.local -- ...`). Bare values never in files; `.env.local` is gitignored; only `.env.template` (with `op://` references) is committed.
+- All secrets via 1Password (`op run --account my.1password.com --env-file=.env.local -- ...`). Bare values never in files; `.env.local` is gitignored; only `.env.template` (with `op://` references) is committed.
 - Idempotent operations: every upsert keys on a stable hash; the pipeline is safe to rerun.
 - No em dashes in any user-facing output (digest, dashboard copy, popups). Use a colon, comma, or " - " instead.
 - Every commit updates `PROJECT_PROGRESS.md`.

--- a/dashboard/pages/3_News.py
+++ b/dashboard/pages/3_News.py
@@ -36,7 +36,7 @@ def main() -> None:
     if source.backend == "yaml" or not news:
         st.info(
             "No news yet. The weekly pipeline will populate this page once it runs. "
-            "Run manually with: `op run --env-file=.env.local -- python "
+            "Run manually with: `op run --account my.1password.com --env-file=.env.local -- python "
             "scripts/run_weekly_pipeline.py`"
         )
         render_footer()

--- a/dashboard/pages/4_Digest.py
+++ b/dashboard/pages/4_Digest.py
@@ -34,7 +34,7 @@ def main() -> None:
     if not files:
         st.info(
             "No digests yet. The weekly pipeline will write one each Monday morning "
-            "(Sydney time). Trigger one manually with `op run --env-file=.env.local "
+            "(Sydney time). Trigger one manually with `op run --account my.1password.com --env-file=.env.local "
             "-- python scripts/run_weekly_pipeline.py`."
         )
         render_footer()

--- a/dashboard/pages/90_Admin.py
+++ b/dashboard/pages/90_Admin.py
@@ -40,7 +40,7 @@ def _check_password() -> bool:
     if not expected:
         st.error(
             "ADMIN_PASSWORD is not set. Run via "
-            "`op run --env-file=.env.local -- streamlit run dashboard/streamlit_app.py`."
+            "`op run --account my.1password.com --env-file=.env.local -- streamlit run dashboard/streamlit_app.py`."
         )
         return False
     with st.form("admin_login"):

--- a/dashboard/streamlit_app.py
+++ b/dashboard/streamlit_app.py
@@ -1,7 +1,7 @@
 """Entry point for the AI Sector Watch Streamlit dashboard.
 
 Run locally:
-    op run --env-file=.env.local -- streamlit run dashboard/streamlit_app.py
+    op run --account my.1password.com --env-file=.env.local -- streamlit run dashboard/streamlit_app.py
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ def main() -> None:
     if source.backend == "yaml":
         st.info(
             "Running against the local seed YAML (no SUPABASE_DB_URL set). "
-            "Set up Supabase and re-run with `op run --env-file=.env.local -- "
+            "Set up Supabase and re-run with `op run --account my.1password.com --env-file=.env.local -- "
             "streamlit run dashboard/streamlit_app.py` to see live data."
         )
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,7 +24,7 @@ For v0 these are mirrored from 1Password into repo secrets manually. For v1 we'l
 Local:
 
 ```bash
-op run --env-file=.env.local -- python scripts/run_weekly_pipeline.py --limit 5
+op run --account my.1password.com --env-file=.env.local -- python scripts/run_weekly_pipeline.py --limit 5
 ```
 
 Production (via gh):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dev = [
     "pytest-cov>=5.0.0",
     "ruff>=0.6.0",
     "black>=24.8.0",
-    "responses>=0.25.0",
 ]
 
 [tool.setuptools]

--- a/scripts/finish_issue.sh
+++ b/scripts/finish_issue.sh
@@ -23,7 +23,9 @@ if [[ -z "$MAIN_WT" ]]; then
 fi
 
 # Find the worktree directory that matches this issue number.
-WT_LINE=$(git -C "$MAIN_WT" worktree list --porcelain | grep -B1 "branch refs/heads/.*${ISSUE}-" | grep "^worktree " | head -1)
+# `git worktree list --porcelain` puts the worktree path TWO lines above
+# the branch line (worktree, HEAD, branch), so we need -B2 (not -B1).
+WT_LINE=$(git -C "$MAIN_WT" worktree list --porcelain | grep -B2 "branch refs/heads/.*${ISSUE}-" | grep "^worktree " | head -1)
 WT_DIR="${WT_LINE#worktree }"
 
 if [[ -z "$WT_DIR" ]]; then

--- a/scripts/run_weekly_pipeline.py
+++ b/scripts/run_weekly_pipeline.py
@@ -2,9 +2,9 @@
 """Run the weekly ingestion pipeline.
 
 Usage:
-    op run --env-file=.env.local -- python scripts/run_weekly_pipeline.py
-    op run --env-file=.env.local -- python scripts/run_weekly_pipeline.py --dry-run
-    op run --env-file=.env.local -- python scripts/run_weekly_pipeline.py --limit 5
+    op run --account my.1password.com --env-file=.env.local -- python scripts/run_weekly_pipeline.py
+    op run --account my.1password.com --env-file=.env.local -- python scripts/run_weekly_pipeline.py --dry-run
+    op run --account my.1password.com --env-file=.env.local -- python scripts/run_weekly_pipeline.py --limit 5
 
 Dry-run mode skips Supabase writes but still exercises source fetches and the
 LLM extraction step (subject to the budget cap).

--- a/scripts/seed_companies.py
+++ b/scripts/seed_companies.py
@@ -6,7 +6,7 @@ geocoder, then upserts each company with `discovery_status = 'verified'`.
 Idempotent: re-running is a no-op for unchanged rows.
 
 Usage:
-    op run --env-file=.env.local -- python scripts/seed_companies.py
+    op run --account my.1password.com --env-file=.env.local -- python scripts/seed_companies.py
     python scripts/seed_companies.py --dry-run   # validate only, no DB writes
 """
 

--- a/scripts/start_issue.sh
+++ b/scripts/start_issue.sh
@@ -150,6 +150,35 @@ if [[ -d "$MAIN_WT/.venv" && ! -e "$WT_DIR/.venv" ]]; then
   esac
 fi
 
+# Step 6.5: move the Project card to "In Progress".
+# Project metadata is hard-coded for this repo because gh has no nice
+# generic way to look it up. If you ever rename or recreate the project,
+# update these constants.
+PROJECT_NUMBER=3
+PROJECT_OWNER="SCClifton"
+PROJECT_ID="PVT_kwHOCnSDOc4BVz2x"
+WORKFLOW_FIELD_ID="PVTSSF_lAHOCnSDOc4BVz2xzhRNAXY"
+WORKFLOW_IN_PROGRESS="e00b541b"
+
+set +e
+ITEM_ID=$(
+  gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json --limit 200 \
+    | jq -r --argjson n "$ISSUE" '.items[] | select(.content.number == $n) | .id' \
+    | head -1
+)
+if [[ -n "$ITEM_ID" && "$ITEM_ID" != "null" ]]; then
+  gh project item-edit \
+    --id "$ITEM_ID" \
+    --project-id "$PROJECT_ID" \
+    --field-id "$WORKFLOW_FIELD_ID" \
+    --single-select-option-id "$WORKFLOW_IN_PROGRESS" >/dev/null 2>&1 \
+    && echo "    Project Workflow set to In Progress" \
+    || echo "    (could not move Project card; do it manually)"
+else
+  echo "    Issue not on Project board yet; skipping Workflow move"
+fi
+set -e
+
 # Step 7: print next steps.
 cat <<EOF
 
@@ -161,7 +190,11 @@ cd into the worktree:
 Make your first commit, then open a Draft PR:
   gh pr create --draft --title "[#$ISSUE] $TITLE" --body "Closes #$ISSUE"
 
-Move the Project card to "In Progress" (Workflow field) via the GitHub UI.
+Run secret-bearing commands with the explicit 1Password account, otherwise
+\`op run\` either uses the wrong account or times out on biometric auth:
+  op run --account my.1password.com --env-file=.env.local -- <your command>
+
+Project card has already been moved to "In Progress".
 
 When ready for review, mark the PR as ready and ping Sam.
 

--- a/scripts/verify_setup.py
+++ b/scripts/verify_setup.py
@@ -2,8 +2,8 @@
 """Smoke checks for AI Sector Watch local + Supabase + secret state.
 
 Usage:
-    op run --env-file=.env.local -- python scripts/verify_setup.py
-    op run --env-file=.env.local -- python scripts/verify_setup.py --apply-schema
+    op run --account my.1password.com --env-file=.env.local -- python scripts/verify_setup.py
+    op run --account my.1password.com --env-file=.env.local -- python scripts/verify_setup.py --apply-schema
 
 Exits non-zero if any required check FAILs. WARN does not affect exit code.
 """

--- a/src/ai_sector_watch/config.py
+++ b/src/ai_sector_watch/config.py
@@ -11,16 +11,41 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _load_env_once() -> None:
-    """Load .env.local if present (no-op in CI, where env vars are set directly)."""
+    """Load .env.local if present, but skip op:// references.
+
+    `.env.local` exists for two purposes: (1) hold non-secret config the same
+    way `.env.template` does, and (2) document op:// references that get
+    resolved at process start by `op run --account my.1password.com --env-file=.env.local -- <cmd>`.
+
+    If a Python process imports `ai_sector_watch.config` *without* having
+    been invoked via `op run`, the values are still raw `op://` strings.
+    Pushing those into `os.environ` is worse than leaving the variable
+    unset, because downstream code (psycopg, the Anthropic SDK) will treat
+    them as the actual secret and fail in confusing ways.
+
+    Solution: parse the file ourselves with `dotenv_values` and only push
+    values that are NOT op:// references into the environment. The op
+    references are loaded by `op run` directly and never need to flow
+    through this function.
+
+    Idempotent: never overwrites a variable already set by the parent shell
+    (so `op run` always wins).
+    """
     env_local = REPO_ROOT / ".env.local"
-    if env_local.exists():
-        load_dotenv(env_local)
+    if not env_local.exists():
+        return
+    for key, value in dotenv_values(env_local).items():
+        if value is None:
+            continue
+        if value.startswith("op://"):
+            continue
+        os.environ.setdefault(key, value)
 
 
 _load_env_once()

--- a/src/ai_sector_watch/extraction/claude_client.py
+++ b/src/ai_sector_watch/extraction/claude_client.py
@@ -104,7 +104,7 @@ class ClaudeClient:
             cfg = get_config()
             if not cfg.anthropic_api_key:
                 raise RuntimeError(
-                    "ANTHROPIC_API_KEY not set; run via op run --env-file=.env.local -- ..."
+                    "ANTHROPIC_API_KEY not set; run via op run --account my.1password.com --env-file=.env.local -- ..."
                 )
             self._client = Anthropic(api_key=cfg.anthropic_api_key)
         return self._client

--- a/src/ai_sector_watch/storage/supabase_db.py
+++ b/src/ai_sector_watch/storage/supabase_db.py
@@ -34,7 +34,9 @@ LOGGER = logging.getLogger(__name__)
 def _get_db_url() -> str:
     url = os.environ.get("SUPABASE_DB_URL")
     if not url:
-        raise KeyError("SUPABASE_DB_URL is not set. Run with `op run --env-file=.env.local -- ...`")
+        raise KeyError(
+            "SUPABASE_DB_URL is not set. Run with `op run --account my.1password.com --env-file=.env.local -- ...`"
+        )
     return url
 
 


### PR DESCRIPTION
## Summary

Audit cleanup before Stream A/B fan-out. Closes #11.

## Why

The audit before launching parallel agent sessions surfaced six issues. Each is small individually, but together they would have wasted 5-15 min per agent session and risked one real merge conflict (Codex's Firecrawl plan vs Stream B). This PR ships them as one bundle.

## Changes

- **B2 (op-run account):** Every documented `op run` uses `--account my.1password.com` so it picks the right vault. Without it, bash sessions either pick the wrong account or time out on biometric auth.
- **New bug found during audit (dotenv loads op refs):** `config.py` was using `load_dotenv(.env.local)` at import time, pushing the `op://` references into `os.environ` as literal strings. Downstream code treated those as real secrets (psycopg dialled `op://` as the DSN, live-db tests stopped skipping). Loader now uses `dotenv_values`, skips `op://` values, and only sets vars not already in the parent env.
- **C4 (Workflow auto-move):** `scripts/start_issue.sh` moves the Project card to `In Progress` via `gh project item-edit` on claim. Falls back to a print if the issue isn't on the board.
- **C5 (finish_issue grep):** `-B1` → `-B2` so the worktree-detection grep finds the matching directory line in `git worktree list --porcelain` output.
- **C2 (PROGRESS rule):** AGENTS.md, CONTRIBUTING.md, PR template loosened to "milestones only" so parallel PRs don't serialise on conflicts in one file.
- **F3 (dead dep):** drop unused `responses` dev dep.

Plus one file reformatted under the current black version.

## Test plan

- [x] `pytest -q` passes (88 pass, 2 skipped — live-db tests skip cleanly now thanks to the dotenv fix)
- [x] `ruff check .` passes
- [x] `black --check .` passes
- [x] Manual smoke: `op read --account my.1password.com op://...` resolves all three refs
- [x] Manual smoke: this PR was created from a worktree spawned by the new `start_issue.sh`, so the Workflow auto-move and the worktree path were dogfooded

## Multi-agent coordination

- [x] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [x] I am the assignee on issue #11
- [x] Branch is `claude-code/11-audit-cleanup-op-account-fix-workflow-au`
- [x] Rebased on latest `main` (eeeecd7 from issue #1)

## Related

Closes #11.