### PR TITLE
[#19] start_issue.sh: print 1Password signin reminder

### DIFF
--- a/scripts/start_issue.sh
+++ b/scripts/start_issue.sh
@@ -187,11 +187,14 @@ cat <<EOF
 cd into the worktree:
   cd $WT_DIR
 
+Cache 1Password auth ONCE for this shell session (one Touch ID tap, then
+~30 minutes of free op access; without this, every op call re-prompts):
+  eval \$(op signin --account my.1password.com)
+
 Make your first commit, then open a Draft PR:
   gh pr create --draft --title "[#$ISSUE] $TITLE" --body "Closes #$ISSUE"
 
-Run secret-bearing commands with the explicit 1Password account, otherwise
-\`op run\` either uses the wrong account or times out on biometric auth:
+Run secret-bearing commands with the explicit 1Password account:
   op run --account my.1password.com --env-file=.env.local -- <your command>
 
 Project card has already been moved to "In Progress".


### PR DESCRIPTION
## Summary

One-line addition to scripts/start_issue.sh's next-steps printout. Tells the agent to run \`eval \$(op signin --account my.1password.com)\` once after \`cd\`-ing into the worktree. One Touch ID tap caches the session for ~30 minutes; without it, every op call re-prompts.

## Test plan

- [x] pytest -q passes (88, 2 skipped)
- [x] ruff check . passes
- [x] black --check . passes
- [x] Manual: read the new printout, confirm the new block is present

## Multi-agent coordination

- [x] Followed pre-flight via scripts/start_issue.sh 19 claude-code
- [x] Branch is claude-code/19-scripts-start-issue-sh-print-1password-s
- [x] Rebased on latest main

Closes #19.