### PR TITLE
[#17] Wire Capital Brief RSS source

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -2,6 +2,24 @@
 
 Chronological log of what shipped, what was tested, and known limitations. Update on every commit.
 
+## 2026-04-27 - Issue #17: Capital Brief source
+
+**Shipped (codex/17-wire-capital-brief-rss-source-into-the-p):**
+- Confirmed Capital Brief does not expose a native RSS or Atom feed at common feed paths.
+- Added `GoogleNewsSitemapSource` for publishers that expose Google News sitemap XML.
+- Registered `capital_brief` in the weekly pipeline using `https://www.capitalbrief.com/sitemap/news.xml`, the XML endpoint advertised in Capital Brief's `robots.txt`.
+- Updated `docs/sources.md` to mark Capital Brief as a News sitemap source.
+- Added a fixture-driven Capital Brief sitemap parser test.
+
+**Tested:**
+- `pytest tests/test_rss_sources.py -q`: 10 pass.
+- `pytest -q`: pass, 2 skipped live DB tests.
+- `ruff check .`: clean.
+- `black --check .`: clean.
+
+**Known limitations:**
+- This is not a native Capital Brief RSS feed. It uses Capital Brief's advertised Google News sitemap because no RSS or Atom endpoint could be confirmed.
+
 ## 2026-04-27 - Issue #16: Digest LLM spend metrics
 
 **Shipped (codex/16-surface-running-llm-spend-on-the-digest):**
@@ -331,7 +349,6 @@ Chronological log of what shipped, what was tested, and known limitations. Updat
 **Known limitations:**
 - `ANTHROPIC_API_KEY` and `ADMIN_PASSWORD` are still unset locally, so `verify_setup.py` reports WARN for those checks.
 - Local `black --check .` currently reports pre-existing formatting changes across 19 Python files unrelated to issue #1.
-
 
 
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -14,7 +14,7 @@ To add a source: create a new module under `src/ai_sector_watch/sources/` that s
 | techcrunch_ai | https://techcrunch.com/category/artificial-intelligence/feed/ | News | Low | Global; filter for ANZ mentions |
 | startup_daily_au | https://www.startupdaily.net/feed/ | News | High |  |
 | smartcompany_startups | https://www.smartcompany.com.au/startupsmart/feed/ | News | High |  |
-| capital_brief | TBC | News | High | Confirm RSS endpoint before commit 09 |
+| capital_brief | https://www.capitalbrief.com/sitemap/news.xml | News sitemap | High | Google News sitemap advertised in robots.txt; native RSS not published as of 2026-04-27 |
 | airtree_open_source_vc | https://www.airtree.vc/open-source-vc/rss.xml | Blog | High |  |
 | blackbird_blog | https://www.blackbird.vc/blog/feed | Blog | High |  |
 | crunchbase_ai | https://news.crunchbase.com/sections/ai/feed/ | News | Medium |  |

--- a/src/ai_sector_watch/pipeline/weekly.py
+++ b/src/ai_sector_watch/pipeline/weekly.py
@@ -37,6 +37,7 @@ from ai_sector_watch.sources import (
     arxiv_source,
     huggingface_papers,
     rss,
+    sitemap,
 )
 from ai_sector_watch.sources.base import RawItem, SourceBase
 from ai_sector_watch.storage import supabase_db
@@ -51,6 +52,7 @@ def default_sources() -> list[SourceBase]:
     return [
         rss.startup_daily_au(),
         rss.smartcompany_startups(),
+        sitemap.capital_brief(),
         rss.airtree_open_source_vc(),
         rss.blackbird_blog(),
         rss.crunchbase_ai(),

--- a/src/ai_sector_watch/sources/sitemap.py
+++ b/src/ai_sector_watch/sources/sitemap.py
@@ -1,0 +1,101 @@
+"""XML sitemap sources for publishers without RSS or Atom feeds."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from xml.etree import ElementTree
+
+import httpx
+
+from ai_sector_watch.sources.base import RawItem, SourceBase
+from ai_sector_watch.sources.rss import DEFAULT_TIMEOUT, USER_AGENT
+
+SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+NEWS_NS = {
+    **SITEMAP_NS,
+    "news": "http://www.google.com/schemas/sitemap-news/0.9",
+}
+
+
+class GoogleNewsSitemapSource(SourceBase):
+    """Fetch a Google News sitemap and emit one RawItem per URL entry."""
+
+    kind = "news"
+
+    def __init__(self, slug: str, url: str, *, kind: str = "news") -> None:
+        super().__init__(slug=slug, kind=kind)
+        self.url = url
+
+    def _http_get(self) -> bytes:
+        with httpx.Client(timeout=DEFAULT_TIMEOUT, headers={"User-Agent": USER_AGENT}) as c:
+            response = c.get(self.url, follow_redirects=True)
+            response.raise_for_status()
+            return response.content
+
+    def fetch(self, *, limit: int | None = None) -> list[RawItem]:
+        """Fetch and parse the sitemap."""
+        body = self._http_get()
+        return parse_google_news_sitemap_bytes(body, slug=self.slug, limit=limit)
+
+
+def parse_google_news_sitemap_bytes(
+    body: bytes, *, slug: str, limit: int | None = None
+) -> list[RawItem]:
+    """Parse raw Google News sitemap bytes into RawItems."""
+    root = ElementTree.fromstring(body)
+    items: list[RawItem] = []
+    for url_node in root.findall("sm:url", SITEMAP_NS):
+        loc = _node_text(url_node, "sm:loc", SITEMAP_NS)
+        news_node = url_node.find("news:news", NEWS_NS)
+        title = _node_text(news_node, "news:title", NEWS_NS) if news_node is not None else None
+        if not loc or not title:
+            continue
+        publication_date = (
+            _node_text(news_node, "news:publication_date", NEWS_NS)
+            if news_node is not None
+            else None
+        )
+        publication_name = (
+            _node_text(news_node, "news:publication/news:name", NEWS_NS)
+            if news_node is not None
+            else None
+        )
+        items.append(
+            RawItem(
+                source_slug=slug,
+                url=loc,
+                title=title,
+                summary=None,
+                published_at=_parse_datetime(publication_date),
+                raw={"publication": publication_name},
+            )
+        )
+        if limit is not None and len(items) >= limit:
+            break
+    return items
+
+
+def capital_brief() -> GoogleNewsSitemapSource:
+    """Return the Capital Brief Google News sitemap source."""
+    return GoogleNewsSitemapSource(
+        "capital_brief",
+        "https://www.capitalbrief.com/sitemap/news.xml",
+    )
+
+
+def _node_text(
+    node: ElementTree.Element | None, path: str, namespaces: dict[str, str]
+) -> str | None:
+    if node is None:
+        return None
+    child = node.find(path, namespaces)
+    if child is None or child.text is None:
+        return None
+    value = child.text.strip()
+    return value or None
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)

--- a/tests/fixtures/sample_capital_brief.xml
+++ b/tests/fixtures/sample_capital_brief.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+  <url>
+    <loc>https://www.capitalbrief.com/article/australian-quantum-startups-seize-on-nvidias-ising-ai-model-in-race-to-viability-8e57db66-4008-41ce-b179-d6547cde1b39/</loc>
+    <news:news>
+      <news:publication>
+        <news:name>Capital Brief</news:name>
+        <news:language>en</news:language>
+      </news:publication>
+      <news:publication_date>2026-04-22T05:00:00.000Z</news:publication_date>
+      <news:title>Australian quantum startups seize on Nvidia's Ising AI model</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://www.capitalbrief.com/briefing/commonwealth-bank-builds-new-ai-agent-to-combat-fraud-6d7f5f1d-2d75-4db1-a5e3-916661b26172/</loc>
+    <news:news>
+      <news:publication>
+        <news:name>Capital Brief</news:name>
+        <news:language>en</news:language>
+      </news:publication>
+      <news:publication_date>2026-04-24T03:25:00.000Z</news:publication_date>
+      <news:title>Commonwealth Bank builds new AI agent to combat fraud</news:title>
+    </news:news>
+  </url>
+  <url>
+    <loc>https://www.capitalbrief.com/article/malformed-entry-without-news-title/</loc>
+  </url>
+</urlset>

--- a/tests/test_rss_sources.py
+++ b/tests/test_rss_sources.py
@@ -1,4 +1,4 @@
-"""Tests for the RSS, arXiv, and HuggingFace sources.
+"""Tests for the RSS, sitemap, arXiv, and HuggingFace sources.
 
 All tests are fixture-driven. No live network calls.
 """
@@ -22,6 +22,10 @@ from ai_sector_watch.sources.huggingface_papers import (
     parse_huggingface_payload,
 )
 from ai_sector_watch.sources.rss import RssSource, parse_feed_bytes
+from ai_sector_watch.sources.sitemap import (
+    capital_brief,
+    parse_google_news_sitemap_bytes,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -67,6 +71,24 @@ def test_rss_source_raises_on_http_error(monkeypatch) -> None:
     source = RssSource("bad", "https://example.com/bad")
     with pytest.raises(httpx.HTTPStatusError):
         source.fetch()
+
+
+def test_parse_google_news_sitemap_bytes_extracts_items() -> None:
+    body = (FIXTURES / "sample_capital_brief.xml").read_bytes()
+    items = parse_google_news_sitemap_bytes(body, slug="capital_brief")
+    assert len(items) >= 1
+    assert items[0].title == "Australian quantum startups seize on Nvidia's Ising AI model"
+    assert items[0].url.startswith("https://www.capitalbrief.com/article/")
+    assert items[0].source_slug == "capital_brief"
+    assert items[0].published_at is not None
+    assert items[0].raw["publication"] == "Capital Brief"
+
+
+def test_capital_brief_factory_uses_news_sitemap() -> None:
+    source = capital_brief()
+    assert source.slug == "capital_brief"
+    assert source.kind == "news"
+    assert source.url == "https://www.capitalbrief.com/sitemap/news.xml"
 
 
 def test_arxiv_factories_have_distinct_slugs() -> None:


### PR DESCRIPTION
Closes #17

## Summary
- Added a Google News sitemap source for Capital Brief because no native RSS or Atom endpoint is published.
- Registered capital_brief in the weekly pipeline.
- Updated docs and added a fixture-driven parser test.

## Tests
- pytest tests/test_rss_sources.py -q
- pytest -q
- ruff check .
- black --check .
- Live smoke: capital_brief().fetch(limit=2)