### PR TITLE
[#4] Run live end-to-end pipeline + verify

### DIFF
--- a/dashboard/components/filters.py
+++ b/dashboard/components/filters.py
@@ -80,10 +80,11 @@ def render_sidebar(meta: FilterMeta, *, default_countries: tuple[str, ...]) -> F
             help="Empty = all stages.",
         )
 
+        valid_defaults = [c for c in default_countries if c in meta.countries]
         countries = st.multiselect(
             "Country",
             options=list(meta.countries),
-            default=list(default_countries),
+            default=valid_defaults,
             help="Default: ANZ. Clear to include everywhere.",
         )
 


### PR DESCRIPTION
## Summary

First live end-to-end run of the weekly pipeline against real Supabase + the real Anthropic API. All v0 success criteria met. One dashboard bug fix piggybacked on the way through (caught during /Map verification, blocked the rest of the work).

## Why

Closes #4. The pipeline had only ever been exercised against fixtures and the YAML seed; this run validates that real RSS sources, real LLM extraction, real Supabase writes, and the /Admin -> /Map promotion flow all work end-to-end.

## Changes

- `dashboard/components/filters.py` - filter `default_countries` to those actually present in `meta.countries` before passing to `st.multiselect`. Without this, /Map raises `StreamlitAPIException` when no verified rows exist.

## Live pipeline run

### Setup

`op run --account my.1password.com --env-file=.env.local -- python scripts/verify_setup.py --apply-schema` printed:

```
[PASS] Python 3.12.x      running 3.12.13
[PASS] ANTHROPIC_API_KEY  set
[PASS] ADMIN_PASSWORD     set
[PASS] digest output dir  data/digests
[PASS] SUPABASE_DB_URL    set
[PASS] Supabase connect   SELECT 1 ok
[PASS] Supabase schema    4/4 tables present (after --apply-schema)
```

### Dry run (`--limit 3`)

```json
{
  "sources_attempted": 11,
  "sources_ok": 8,
  "items_seen": 24,
  "items_new": 2,
  "candidates_added": 3,
  "cost_usd": 0.2747,
  "digest_path": "data/digests/2026-04-27.md"
}
```

3 candidates auto-discovered: Employment Hero (Sydney, AU), Syenta (AU), Ideally (AU).

### Success-criteria run (`--limit 5`)

```json
{
  "sources_attempted": 11,
  "sources_ok": 8,
  "items_seen": 40,
  "items_new": 5,
  "candidates_added": 0,
  "cost_usd": 0.1534,
  "digest_path": "data/digests/2026-04-27.md",
  "errors": [
    "source airtree_open_source_vc failed: 404",
    "source blackbird_blog failed: 404",
    "source yc_launches failed: 404"
  ]
}
```

`candidates_added: 0` for the limit=5 run because the dry run already wrote those URLs (idempotency by URL hash). 3 candidates remained pending in the queue, which satisfies the acceptance criterion. Combined cost across both runs: $0.4281.

## Acceptance criteria

- [x] >= 5 news items ingested - 24 + 40 = 64 seen across both runs, 7 unique new.
- [x] >= 1 candidate added to the auto-discovery queue - 3 from the dry run, still pending.
- [x] Digest written to `data/digests/2026-04-27.md` - confirmed.
- [x] Total LLM spend < $2 - $0.4281 combined.
- [x] Pending candidate visible in the Admin queue - verified in /Admin (Employment Hero, Ideally, Syenta).
- [x] Promoting that candidate makes it appear on the Map page - promoted Employment Hero via /Admin; /Map went from 0 to 1 marker pinned in Sydney.

Screenshots of /Admin pre-promotion and /Map before/after promotion are inline in the verification chat transcript.

## Issues found

1. **Dashboard `Country` filter crash.** Fixed in this PR. Reproduction: empty Supabase, run streamlit, hit /Map. `StreamlitAPIException: The default value 'AU' is not part of the options.`
2. **Three RSS sources are 404.** `airtree_open_source_vc`, `blackbird_blog`, `yc_launches`. Worth a follow-up issue to either remove from `default_sources()` or find current feeds. Did not fix here to keep the PR focused.
3. **Stale `op://` UUID for `SUPABASE_DB_URL` in the local `.env.local`.** Pointed at an item that no longer exists in the vault. Updated locally (only file is `.env.local`, gitignored). Documented for the operator: replace with the UUID of the `Supabase AI Sector Watch` item.
4. **Local `.venv` was broken.** `psycopg` import raised `AttributeError: module 'psycopg.pq' has no attribute 'Format'` due to mixed installs in the symlinked venv. Created a per-worktree venv (`AISW_VENV=own` style) to recover. Main worktree's venv likely needs a clean reinstall.
5. **Issue body suggested `AISW_FORCE_YAML=1 streamlit run`** for the verification, but that flag forces /Map to render YAML seeds and would have hidden the live promotion. Ran without it; the Supabase-backed Map is the correct surface to verify against.

## Test plan

- [x] `pytest -q` passes (84 passed, 2 skipped - Supabase live integration tests skip when `SUPABASE_DB_URL` is unset)
- [x] `ruff check .` passes (`dashboard/components/filters.py`)
- [x] `black --check .` passes (`dashboard/components/filters.py`)
- [x] Manual smoke check: full pipeline run + /Admin login + promotion + /Map verification, all in this PR's commit
- [x] PROJECT_PROGRESS.md not updated - this is a verification milestone, but no new public feature ships. Leaving alone.

## Multi-agent coordination

- [x] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [x] I am the assignee on the linked issue
- [x] Branch is named `claude-code/4-run-live-end-to-end-pipeline-and-verify`
- [x] Rebased on latest `main` (picked up #21, #22, #23)

## Related issues

Closes #4

@SCClifton ready for review when you tap through. Two follow-ups worth their own issues if you agree: dead RSS sources (#1 above) and `PROJECT_PROGRESS.md` rule on whether "first live e2e run" counts as a milestone.
