### PR TITLE
[#5] Provision Azure App Service for the dashboard

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -365,7 +365,20 @@ Chronological log of what shipped, what was tested, and known limitations. Updat
 **Known limitations:**
 - The orchestrator extracts one funding event for the first linked company on a funding-kind article. That matches the current prompt shape and budget estimate.
 
+## 2026-04-27 - Issue #5: Azure App Service provisioned
 
+**Shipped (claude-code/5-provision-azure-app-service-for-the-dash):**
+- Resource group `ai-sector-watch` in `australiaeast`.
+- App Service plan `ai-sector-watch-plan`: Linux, B1, single instance.
+- Web App for Containers `ai-sector-watch` (kind `app,linux,container`), default hostname `ai-sector-watch.azurewebsites.net`. Configured to pull `ghcr.io/scclifton/ai-sector-watch/ai-sector-watch:latest`.
+- App settings written: `WEBSITES_PORT=8000`, `ANTHROPIC_API_KEY`, `SUPABASE_DB_URL`, `ADMIN_PASSWORD` (sourced via `op read --account my.1password.com`), plus `ANTHROPIC_BUDGET_USD_PER_RUN=2` and `ANTHROPIC_MODEL=claude-sonnet-4-6`.
 
+**Tested:**
+- `az webapp show -g ai-sector-watch -n ai-sector-watch` returns the resource: `state=Running`, `linuxFxVersion=DOCKER|ghcr.io/scclifton/ai-sector-watch/ai-sector-watch:latest`.
+- App Service plumbing (TLS, hostname, port routing) verified by temporarily swapping the image to `nginx:stable-alpine` with `WEBSITES_PORT=80`: `curl -I https://ai-sector-watch.azurewebsites.net` returned `HTTP/2 200`. Image and port reverted to the production target.
 
+**Known limitations:**
+- The production GHCR image does not exist yet, so the dashboard URL currently returns `HTTP/2 503`. Issue #6 (deploy.yml: build container, push to GHCR, deploy) closes this. Once that runs, the configured image resolves and the dashboard serves on port 8000.
+- OIDC federated credential and the `AZURE_CLIENT_ID` / `TENANT_ID` / `SUBSCRIPTION_ID` GitHub secrets (deployment.md "OIDC federated credential" section) are deferred to whichever issue wires `deploy.yml` end-to-end.
+- Custom domain `aimap.cliftonfamily.co` and TLS binding are deferred to issue #7 (DNS).
 


### PR DESCRIPTION
Closes #5.

## What changed
Provisioned Azure infrastructure for the dashboard. Code-light: only `PROJECT_PROGRESS.md` updated.

## Provisioned (live in Azure subscription \`Azure subscription 1\`)
| Resource | Name | Notes |
|---|---|---|
| Resource group | \`ai-sector-watch\` | \`australiaeast\` |
| App Service plan | \`ai-sector-watch-plan\` | Linux, B1, single instance |
| Web App for Containers | \`ai-sector-watch\` | Hostname \`ai-sector-watch.azurewebsites.net\`, image set to \`ghcr.io/scclifton/ai-sector-watch/ai-sector-watch:latest\` |

App settings written:
- \`WEBSITES_PORT=8000\`
- \`ANTHROPIC_API_KEY\` (from \`op://.../Anthropic API Key/credential\`)
- \`SUPABASE_DB_URL\` (from \`op://.../Supabase AI Sector Watch/connection_string\`)
- \`ADMIN_PASSWORD\` (from \`op://.../AI Sector Watch Admin/password\`)
- \`ANTHROPIC_BUDGET_USD_PER_RUN=2\`
- \`ANTHROPIC_MODEL=claude-sonnet-4-6\`

## Verified
- \`az webapp show -g ai-sector-watch -n ai-sector-watch\` returns the resource (\`state=Running\`).
- App Service plumbing (TLS, hostname, port routing) confirmed by temporarily swapping the image to \`nginx:stable-alpine\` with \`WEBSITES_PORT=80\`: \`curl -I https://ai-sector-watch.azurewebsites.net\` returned \`HTTP/2 200\`. Image and port reverted to the production target.

## Out of scope (deferred)
- The production GHCR image does not exist yet. Until issue #6 (build + push container, run \`deploy.yml\`) lands, \`curl -I https://ai-sector-watch.azurewebsites.net\` returns 503.
- OIDC federated credential + \`AZURE_CLIENT_ID\` / \`AZURE_TENANT_ID\` / \`AZURE_SUBSCRIPTION_ID\` repo secrets: deferred to whichever issue wires \`deploy.yml\` end-to-end.
- Custom domain \`aimap.cliftonfamily.co\` + Azure-managed TLS: issue #7.

## Multi-agent coordination
- [x] Issue #5 self-assigned, Project moved to In Progress.
- [x] Per-issue worktree at \`../AI-Sector-Watch-5-provision-azure-app-service-for-the-dash/\`.
- [x] Coordination signal posted on issue #5 before any \`az\` write op.
- [x] No commits to \`main\`.

## Before merging this PR
- [ ] Confirm \`curl -I https://ai-sector-watch.azurewebsites.net\` returns \`HTTP/2 200\`. This requires the production container image to exist on GHCR (gated on issue #6's deploy pipeline running successfully).