### PR TITLE
[#33] Firecrawl enrichment client + pipeline wiring

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,9 +10,11 @@
 ANTHROPIC_API_KEY=op://Private/<anthropic-item-uuid>/credential
 SUPABASE_DB_URL=op://Private/<supabase-item-uuid>/connection_string
 ADMIN_PASSWORD=op://Private/<admin-item-uuid>/password
+FIRECRAWL_API_KEY=op://Private/<firecrawl-item-uuid>/credential
 
 # Non-secret config:
 PIPELINE_LOG_LEVEL=INFO
 DIGEST_OUTPUT_DIR=./data/digests
 ANTHROPIC_BUDGET_USD_PER_RUN=2
 ANTHROPIC_MODEL=claude-sonnet-4-6
+FIRECRAWL_BUDGET_CREDITS_PER_RUN=200

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -43,6 +43,9 @@ gh run watch
 
 - The pipeline hard-caps Anthropic spend per run via `ANTHROPIC_BUDGET_USD_PER_RUN` (default $2). When the cap is hit mid-run, the orchestrator records a `partial` ingest event and writes a digest of what it managed to do.
 - Successful LLM responses are cached on disk under `data/local/claude_cache/` keyed by `(model, system, prompt, schema_class)`. CI runs see a cold cache; local development reruns are free after the first call.
+- Firecrawl enrichment is hard-capped per run via `FIRECRAWL_BUDGET_CREDITS_PER_RUN` (default 200 credits, ~40 candidates at 5 credits each). When the cap is hit, enrichment short-circuits to an empty `CompanyFacts` and the rest of the run continues. The annual budget at realistic load (~8 candidates per week) sits around 2,000 credits out of the 20,000 available.
+- Successful Firecrawl responses are cached on disk under `data/local/firecrawl_cache/` keyed by `(url, json_schema_hash)`. The schema hash means a `CompanyFacts` schema change forces a re-scrape on the next run.
+- The pipeline JSON summary (`scripts/run_weekly_pipeline.py`) reports `firecrawl_credits_used`, `firecrawl_calls`, and `firecrawl_cache_hits` alongside Anthropic spend so spend is observable from cron logs.
 
 ## Rollback
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -28,3 +28,24 @@ To add a source: create a new module under `src/ai_sector_watch/sources/` that s
 - Idempotent: store a hash of each item; skip if seen.
 - Per-source failures must not abort the run; log and continue.
 - Never bypass `robots.txt`; never scrape HTML when an RSS or API feed exists.
+
+## Enrichment
+
+Discovery sources tell the pipeline that a company exists; enrichment fills in
+authoritative fields directly from the company's own website. Enrichment runs
+after LLM validation and before classification, only when a website URL is
+known for the candidate.
+
+| Provider | URL | Trigger | Cost | Notes |
+|---|---|---|---|---|
+| Firecrawl | https://www.firecrawl.dev/ | Per new ANZ candidate with a known website | ~5 credits per scrape (1 scrape + 4 JSON-mode extract) | Implementation: `src/ai_sector_watch/extraction/firecrawl_client.py`. JSON-mode extract uses the `CompanyFacts` schema. |
+
+Skipped when:
+
+- The candidate already exists in the DB (idempotent).
+- No website is known (LLM validator did not return one).
+- The per-run credit cap (`FIRECRAWL_BUDGET_CREDITS_PER_RUN`, default 200) is reached.
+
+Successful responses are cached on disk under `data/local/firecrawl_cache/` so
+reruns do not re-spend credits. The cache key includes the JSON-Schema hash so
+a schema change forces a re-scrape.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "anthropic>=0.40.0",
     "feedparser>=6.0.11",
     "arxiv>=2.1.3",
+    "firecrawl-py>=2.0.0",
     "httpx>=0.27.0",
     "psycopg[binary]>=3.2.0",
     "pydantic>=2.8.0",

--- a/scripts/run_weekly_pipeline.py
+++ b/scripts/run_weekly_pipeline.py
@@ -56,6 +56,9 @@ def main() -> int:
         "items_new": result.items_new,
         "candidates_added": result.candidates_added,
         "cost_usd": round(result.cost_usd, 4),
+        "firecrawl_credits_used": result.firecrawl_credits_used,
+        "firecrawl_calls": result.firecrawl_calls,
+        "firecrawl_cache_hits": result.firecrawl_cache_hits,
         "digest_path": result.digest_path,
         "errors": result.errors,
     }

--- a/src/ai_sector_watch/extraction/firecrawl_client.py
+++ b/src/ai_sector_watch/extraction/firecrawl_client.py
@@ -289,11 +289,39 @@ def _derive_confidence(raw: dict[str, Any]) -> float:
 
 
 def _post_process(facts: CompanyFacts) -> CompanyFacts:
-    """Sanitise user-facing strings: strip em dashes from description / summary."""
+    """Sanitise user-facing strings and recompute confidence from populated fields.
+
+    The LLM tends to either echo the schema default (0.0) or hallucinate a
+    high value regardless of how much it actually filled in. Compute it
+    deterministically here so downstream `confidence > 0` checks behave.
+    """
+    cleaned_description = _sanitise(facts.description)
+    cleaned_summary = _sanitise(facts.last_funding_summary)
+    populated_other = sum(
+        1
+        for v in (
+            facts.founded_year,
+            facts.city,
+            facts.country,
+            cleaned_summary,
+        )
+        if v
+    )
+    if facts.founders:
+        populated_other += 1
+    if facts.sector_keywords:
+        populated_other += 1
+    if cleaned_description and populated_other >= 1:
+        confidence = 1.0
+    elif cleaned_description or populated_other >= 1:
+        confidence = 0.5
+    else:
+        confidence = 0.0
     return facts.model_copy(
         update={
-            "description": _sanitise(facts.description),
-            "last_funding_summary": _sanitise(facts.last_funding_summary),
+            "description": cleaned_description,
+            "last_funding_summary": cleaned_summary,
+            "confidence": confidence,
         }
     )
 

--- a/src/ai_sector_watch/extraction/firecrawl_client.py
+++ b/src/ai_sector_watch/extraction/firecrawl_client.py
@@ -1,0 +1,316 @@
+"""Budget-capped, cached Firecrawl client.
+
+Mirrors the `ClaudeClient` pattern in `claude_client.py`:
+
+- Lazy auth (`FIRECRAWL_API_KEY`) so importing the module never hits the
+  network or fails when the env var is unset (e.g. in CI).
+- Per-run credit cap via `FIRECRAWL_BUDGET_CREDITS_PER_RUN` (default 200).
+  A scrape with JSON-mode extract costs ~5 credits; the cap raises
+  `FirecrawlBudgetExceeded` when the next call would push past the cap.
+- Disk cache under `data/local/firecrawl_cache/{hash}.json`. The cache
+  key is the URL plus the JSON-Schema hash so a schema change forces a
+  re-scrape.
+- Tests should monkey-patch `FirecrawlClient._dispatch()` to avoid
+  hitting the live SDK.
+
+The public entry point for the pipeline is `firecrawl_enrich(client, website)`
+which returns a `CompanyFacts`. It tolerates missing websites and scrape
+failures by returning a low-confidence empty `CompanyFacts`, so the
+caller never has to special-case None.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from ai_sector_watch.config import REPO_ROOT
+from ai_sector_watch.extraction.schema import CompanyFacts
+
+LOGGER = logging.getLogger(__name__)
+CACHE_DIR = REPO_ROOT / "data" / "local" / "firecrawl_cache"
+
+# A scrape (1 credit) plus JSON-mode extract (4 credits) = 5 credits per call.
+DEFAULT_CREDITS_PER_CALL = 5
+DEFAULT_BUDGET_CREDITS_PER_RUN = 200
+
+ENRICH_PROMPT = (
+    "Extract authoritative facts about this company from its own website. "
+    "Use only what the page explicitly states. Leave fields null when the "
+    "page does not say. Do not use em dashes in the description; prefer a "
+    "colon, comma, or ' - '."
+)
+
+_EM_DASH_PATTERN = re.compile(r"\s*[—–]\s*")
+
+
+class FirecrawlBudgetExceeded(RuntimeError):
+    """Raised when a scrape would push the run total past the credit cap."""
+
+
+@dataclass
+class FirecrawlStats:
+    """Running totals for a single FirecrawlClient instance."""
+
+    calls: int = 0
+    cache_hits: int = 0
+    credits_used: int = 0
+    failures: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class FirecrawlResult:
+    """A typed CompanyFacts plus the credits it consumed."""
+
+    facts: CompanyFacts
+    credits_used: int
+    cached: bool
+
+
+def _hash(*parts: str) -> str:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(p.encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+def _sanitise(text: str | None) -> str | None:
+    """Replace em dash and en dash with a hyphen for user-facing copy."""
+    if text is None:
+        return None
+    return _EM_DASH_PATTERN.sub(" - ", text).strip() or None
+
+
+class FirecrawlClient:
+    """Thin wrapper around the Firecrawl Python SDK with budget + caching."""
+
+    def __init__(
+        self,
+        *,
+        budget_credits: int | None = None,
+        credits_per_call: int = DEFAULT_CREDITS_PER_CALL,
+        cache_dir: Path | None = None,
+    ) -> None:
+        self.budget_credits = (
+            budget_credits
+            if budget_credits is not None
+            else int(
+                os.environ.get(
+                    "FIRECRAWL_BUDGET_CREDITS_PER_RUN",
+                    str(DEFAULT_BUDGET_CREDITS_PER_RUN),
+                )
+            )
+        )
+        self.credits_per_call = credits_per_call
+        self.cache_dir = cache_dir or CACHE_DIR
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.stats = FirecrawlStats()
+        self._client = None  # lazy
+
+    @property
+    def firecrawl(self):
+        """Lazy import + lazy auth so tests can avoid the dependency."""
+        if self._client is None:
+            from firecrawl import Firecrawl
+
+            api_key = os.environ.get("FIRECRAWL_API_KEY")
+            if not api_key:
+                raise RuntimeError(
+                    "FIRECRAWL_API_KEY not set; run via op run --account my.1password.com "
+                    "--env-file=.env.local -- ..."
+                )
+            self._client = Firecrawl(api_key=api_key)
+        return self._client
+
+    # -- public ----------------------------------------------------------
+
+    def scrape_facts(self, url: str) -> FirecrawlResult:
+        """Scrape `url` and return JSON-mode-extracted CompanyFacts.
+
+        Raises FirecrawlBudgetExceeded when the next call would exceed
+        the per-run credit cap. On SDK failure, records the failure on
+        `stats.failures` and returns a low-confidence empty CompanyFacts
+        result so the caller can keep going.
+        """
+        schema = CompanyFacts.model_json_schema()
+        cache_key = _hash(url, json.dumps(schema, sort_keys=True))
+
+        cached = self._read_cache(cache_key)
+        if cached is not None:
+            try:
+                facts = CompanyFacts.model_validate(cached["facts"])
+            except ValidationError as exc:
+                LOGGER.warning("firecrawl cache for %s failed validation: %s", cache_key[:8], exc)
+            else:
+                self.stats.cache_hits += 1
+                return FirecrawlResult(
+                    facts=facts,
+                    credits_used=int(cached.get("credits_used", 0)),
+                    cached=True,
+                )
+
+        if self.stats.credits_used + self.credits_per_call > self.budget_credits:
+            raise FirecrawlBudgetExceeded(
+                f"would exceed {self.budget_credits}-credit cap "
+                f"(used {self.stats.credits_used}, next call costs {self.credits_per_call})"
+            )
+
+        try:
+            facts_json = self._dispatch(url=url, schema=schema)
+        except Exception as exc:  # noqa: BLE001 - any SDK failure is a soft failure here
+            self.stats.calls += 1
+            self.stats.failures.append(f"{url}: {type(exc).__name__}: {exc}")
+            LOGGER.warning("firecrawl scrape failed for %s: %s", url, exc)
+            return FirecrawlResult(facts=CompanyFacts.empty(), credits_used=0, cached=False)
+
+        try:
+            facts = self._coerce_facts(facts_json)
+        except ValidationError as exc:
+            self.stats.calls += 1
+            self.stats.failures.append(f"{url}: schema validation: {exc}")
+            LOGGER.warning("firecrawl response for %s did not validate: %s", url, exc)
+            return FirecrawlResult(facts=CompanyFacts.empty(), credits_used=0, cached=False)
+
+        facts = _post_process(facts)
+
+        self.stats.calls += 1
+        self.stats.credits_used += self.credits_per_call
+
+        self._write_cache(
+            cache_key,
+            facts=facts.model_dump(mode="json"),
+            credits_used=self.credits_per_call,
+        )
+        return FirecrawlResult(facts=facts, credits_used=self.credits_per_call, cached=False)
+
+    # -- live dispatch (override-friendly for tests) ---------------------
+
+    def _dispatch(self, *, url: str, schema: dict[str, Any]) -> dict[str, Any]:
+        """Make the actual SDK call. Returns the raw json dict the SDK gave back."""
+        from firecrawl.v2.types import JsonFormat
+
+        formats = [
+            "markdown",
+            JsonFormat(type="json", prompt=ENRICH_PROMPT, schema=schema),
+        ]
+        document = self.firecrawl.scrape(url, formats=formats, only_main_content=True)
+        if document is None or not getattr(document, "json", None):
+            raise RuntimeError("firecrawl returned no json payload")
+        return document.json  # type: ignore[no-any-return]
+
+    # -- internals --------------------------------------------------------
+
+    def _coerce_facts(self, raw: dict[str, Any]) -> CompanyFacts:
+        """Best-effort coercion of the SDK json payload into CompanyFacts.
+
+        The model can return numeric strings or omit list fields entirely;
+        normalise here before letting Pydantic validate.
+        """
+        cleaned: dict[str, Any] = dict(raw)
+
+        founded = cleaned.get("founded_year")
+        if isinstance(founded, str):
+            try:
+                cleaned["founded_year"] = int(founded.strip())
+            except ValueError:
+                cleaned["founded_year"] = None
+
+        for list_field in ("founders", "sector_keywords"):
+            value = cleaned.get(list_field)
+            if value is None:
+                cleaned[list_field] = []
+            elif isinstance(value, str):
+                cleaned[list_field] = [value]
+
+        confidence = cleaned.get("confidence")
+        if confidence is None:
+            cleaned["confidence"] = _derive_confidence(cleaned)
+        elif isinstance(confidence, str):
+            try:
+                cleaned["confidence"] = float(confidence)
+            except ValueError:
+                cleaned["confidence"] = _derive_confidence(cleaned)
+
+        return CompanyFacts.model_validate(cleaned)
+
+    def _cache_path(self, key: str) -> Path:
+        return self.cache_dir / f"{key}.json"
+
+    def _read_cache(self, key: str) -> dict | None:
+        path = self._cache_path(key)
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            LOGGER.warning("firecrawl cache read failed for %s: %s", key[:8], exc)
+            return None
+
+    def _write_cache(self, key: str, *, facts: dict, credits_used: int) -> None:
+        path = self._cache_path(key)
+        try:
+            path.write_text(
+                json.dumps({"facts": facts, "credits_used": credits_used}, sort_keys=True),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            LOGGER.warning("firecrawl cache write failed for %s: %s", key[:8], exc)
+
+
+def _derive_confidence(raw: dict[str, Any]) -> float:
+    """Fallback confidence: 1 if description plus another field present, else 0.5/0.0."""
+    has_description = bool(raw.get("description"))
+    populated = sum(
+        1
+        for k in (
+            "founded_year",
+            "founders",
+            "city",
+            "country",
+            "sector_keywords",
+            "last_funding_summary",
+        )
+        if raw.get(k)
+    )
+    if has_description and populated >= 1:
+        return 1.0
+    if has_description or populated >= 1:
+        return 0.5
+    return 0.0
+
+
+def _post_process(facts: CompanyFacts) -> CompanyFacts:
+    """Sanitise user-facing strings: strip em dashes from description / summary."""
+    return facts.model_copy(
+        update={
+            "description": _sanitise(facts.description),
+            "last_funding_summary": _sanitise(facts.last_funding_summary),
+        }
+    )
+
+
+def firecrawl_enrich(client: FirecrawlClient, website: str | None) -> CompanyFacts:
+    """Pipeline-facing helper: enrich one company website into CompanyFacts.
+
+    Returns CompanyFacts.empty() (confidence=0) when:
+    - website is None or blank,
+    - the SDK call raised any exception,
+    - the response did not validate against CompanyFacts.
+
+    Raises FirecrawlBudgetExceeded when the next call would push past
+    the credit cap; the caller (orchestrator) catches this and records
+    a partial run, same shape as BudgetExceeded in claude_client.
+    """
+    if not website or not website.strip():
+        return CompanyFacts.empty()
+    result = client.scrape_facts(website.strip())
+    return result.facts

--- a/src/ai_sector_watch/extraction/prompts.py
+++ b/src/ai_sector_watch/extraction/prompts.py
@@ -44,6 +44,7 @@ Context (from the news item that mentioned it):
 If the name is ambiguous (multiple companies share it), set `is_valid` false.
 If the company exists but is not in any AI/ML space, set `is_ai_company` false.
 Set `canonical_name` only if the input is a misspelling or short form (e.g. "marqo.io" -> "Marqo").
+Set `website` to the company's homepage URL only if the article mentions it or you know it with high confidence. Use null if unknown. Do not guess.
 """
 
 CLASSIFY_COMPANY_SYSTEM = (

--- a/src/ai_sector_watch/extraction/schema.py
+++ b/src/ai_sector_watch/extraction/schema.py
@@ -42,6 +42,13 @@ class CompanyValidation(BaseModel):
     is_ai_company: bool
     reasoning: str
     canonical_name: str | None = None
+    website: str | None = Field(
+        None,
+        description=(
+            "Company website URL if the article mentions it or you know it "
+            "with high confidence (e.g. linked in the article). Null if unknown."
+        ),
+    )
 
 
 class CompanyClassification(BaseModel):
@@ -79,3 +86,58 @@ class NewsClassification(BaseModel):
         ...,
         description="True if the item is relevant to the ANZ AI ecosystem.",
     )
+
+
+class CompanyFacts(BaseModel):
+    """Firecrawl-extracted facts about a company from its own website.
+
+    Used as additional context for the classifier and for direct upsert
+    of structured fields (founded_year, founders, etc) on the company
+    row. `confidence` is 0 when the scrape returned nothing usable and
+    rises as more fields come back populated.
+    """
+
+    founded_year: int | None = Field(
+        None,
+        description="Year the company was founded, if stated on the website.",
+        ge=1900,
+        le=2100,
+    )
+    description: str | None = Field(
+        None,
+        description=(
+            "One or two sentence company description in the company's own "
+            "words. Do not use em dashes; use a colon, comma, or ' - ' instead."
+        ),
+    )
+    founders: list[str] = Field(
+        default_factory=list,
+        description="Founder names if listed on About / Team / LinkedIn-style pages.",
+    )
+    city: str | None = Field(None, description="HQ city if stated.")
+    country: str | None = Field(None, description="HQ country code (AU, NZ, US, ...) if stated.")
+    sector_keywords: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Free-form sector / category keywords pulled from the page "
+            "(vector search, RAG, biotech, ...)."
+        ),
+    )
+    last_funding_summary: str | None = Field(
+        None,
+        description=(
+            "Most recent funding event in one short sentence, if mentioned "
+            "(round, lead, amount)."
+        ),
+    )
+    confidence: float = Field(
+        0.0,
+        ge=0.0,
+        le=1.0,
+        description="0 when scrape failed or empty; rises as more fields come back populated.",
+    )
+
+    @classmethod
+    def empty(cls) -> CompanyFacts:
+        """Low-confidence empty placeholder used when no website is known or scrape failed."""
+        return cls(confidence=0.0)

--- a/src/ai_sector_watch/pipeline/weekly.py
+++ b/src/ai_sector_watch/pipeline/weekly.py
@@ -28,13 +28,22 @@ from ai_sector_watch.extraction.claude_client import (
     BudgetExceeded,
     ClaudeClient,
 )
+from ai_sector_watch.extraction.firecrawl_client import (
+    FirecrawlBudgetExceeded,
+    FirecrawlClient,
+    firecrawl_enrich,
+)
 from ai_sector_watch.extraction.prompts import (
     EXTRACT_COMPANIES_SYSTEM,
     EXTRACT_COMPANIES_USER_TEMPLATE,
     EXTRACT_FUNDING_SYSTEM,
     EXTRACT_FUNDING_USER_TEMPLATE,
 )
-from ai_sector_watch.extraction.schema import CompanyMentionList, FundingExtraction
+from ai_sector_watch.extraction.schema import (
+    CompanyFacts,
+    CompanyMentionList,
+    FundingExtraction,
+)
 from ai_sector_watch.sources import (
     arxiv_source,
     huggingface_papers,
@@ -75,6 +84,9 @@ class PipelineResult:
     items_new: int = 0
     candidates_added: int = 0
     cost_usd: float = 0.0
+    firecrawl_credits_used: int = 0
+    firecrawl_calls: int = 0
+    firecrawl_cache_hits: int = 0
     digest_path: str | None = None
     new_companies: list[str] = field(default_factory=list)
     news_summary: list[dict] = field(default_factory=list)
@@ -85,6 +97,7 @@ def run_weekly_pipeline(
     *,
     sources: Iterable[SourceBase] | None = None,
     client: ClaudeClient | None = None,
+    firecrawl_client: FirecrawlClient | None = None,
     items_per_source: int = 25,
     write_to_db: bool = True,
     digest_date: date | None = None,
@@ -96,6 +109,7 @@ def run_weekly_pipeline(
     """
     sources = list(sources) if sources is not None else default_sources()
     client = client or ClaudeClient()
+    firecrawl_client = firecrawl_client or FirecrawlClient()
     result = PipelineResult()
     today = digest_date or datetime.now(UTC).date()
     raw_items: list[RawItem] = []
@@ -170,26 +184,41 @@ def run_weekly_pipeline(
                 if not val_mod.is_acceptable(validation):
                     continue
 
+                # 2. Firecrawl enrichment: scrape the company website for
+                # authoritative facts before the classifier runs. Skipped if
+                # no website is known. A scrape failure is non-fatal: facts
+                # comes back with confidence=0 and we fall through.
+                try:
+                    facts = firecrawl_enrich(firecrawl_client, validation.website)
+                except FirecrawlBudgetExceeded as exc:
+                    result.errors.append(
+                        f"firecrawl budget exceeded after "
+                        f"{firecrawl_client.stats.credits_used} credits: {exc}"
+                    )
+                    facts = CompanyFacts.empty()
+
                 try:
                     classification = cls_mod.classify_company(
                         client,
                         name=mention.name,
-                        context=item.title + "\n\n" + (item.summary or ""),
+                        context=_classifier_context(item, facts),
                     )
                 except BudgetExceeded as exc:
                     result.errors.append(f"budget exceeded: {exc}")
                     break
 
-                geo = geocode_city(mention.city, jitter_seed=mention.name)
+                geo = geocode_city(facts.city or mention.city, jitter_seed=mention.name)
                 company_id = supabase_db.upsert_company(
                     conn,
                     name=validation.canonical_name or mention.name,
-                    country=mention.country or "AU",
-                    city=geo.city if geo else mention.city,
+                    country=facts.country or mention.country or "AU",
+                    city=geo.city if geo else (facts.city or mention.city),
                     lat=geo.lat if geo else None,
                     lon=geo.lon if geo else None,
+                    website=validation.website,
                     sector_tags=classification.sector_tags,
                     stage=classification.stage,
+                    founded_year=facts.founded_year,
                     summary=classification.summary,
                     discovery_status="auto_discovered_pending_review",
                     discovery_source=item.source_slug,
@@ -273,7 +302,13 @@ def run_weekly_pipeline(
             conn,
             source_slug="pipeline",
             kind="weekly_run",
-            payload={"date": today.isoformat(), "cost_usd": client.stats.cost_usd},
+            payload={
+                "date": today.isoformat(),
+                "cost_usd": client.stats.cost_usd,
+                "firecrawl_credits_used": firecrawl_client.stats.credits_used,
+                "firecrawl_calls": firecrawl_client.stats.calls,
+                "firecrawl_cache_hits": firecrawl_client.stats.cache_hits,
+            },
             window_start=datetime.combine(today, datetime.min.time(), tzinfo=UTC),
             window_end=datetime.now(UTC),
             status="ok" if not result.errors else "partial",
@@ -285,12 +320,35 @@ def run_weekly_pipeline(
         conn.commit()
 
     result.cost_usd = client.stats.cost_usd
+    result.firecrawl_credits_used = firecrawl_client.stats.credits_used
+    result.firecrawl_calls = firecrawl_client.stats.calls
+    result.firecrawl_cache_hits = firecrawl_client.stats.cache_hits
 
     # 6. Digest --------------------------------------------------------
     digest_path = _write_digest(today, result)
     result.digest_path = str(digest_path)
 
     return result
+
+
+def _classifier_context(item: RawItem, facts: CompanyFacts) -> str:
+    """Build the classify-company context: news summary + enriched facts.
+
+    Facts only get appended when the scrape returned something useful
+    (confidence > 0); otherwise the context is identical to the
+    pre-Firecrawl behaviour.
+    """
+    news_summary = item.title + "\n\n" + (item.summary or "")
+    if facts.confidence <= 0:
+        return news_summary
+    chunks: list[str] = [news_summary]
+    if facts.description:
+        chunks.append(f"Company description (from website): {facts.description}")
+    if facts.sector_keywords:
+        chunks.append("Sector keywords (from website): " + ", ".join(facts.sector_keywords))
+    if facts.founded_year:
+        chunks.append(f"Founded: {facts.founded_year}")
+    return "\n\n".join(chunks)
 
 
 def _extract_mentions(client: ClaudeClient, item: RawItem) -> CompanyMentionList:

--- a/tests/test_firecrawl.py
+++ b/tests/test_firecrawl.py
@@ -250,3 +250,24 @@ def test_post_process_strips_em_dashes_from_facts() -> None:
     assert "—" not in cleaned.description
     assert cleaned.last_funding_summary is not None
     assert "—" not in cleaned.last_funding_summary
+
+
+def test_post_process_recomputes_confidence_from_populated_fields() -> None:
+    """Model-emitted confidence is overridden so downstream `>0` checks behave."""
+    # Model returned 0.0 but description + 3 other fields are populated.
+    rich = CompanyFacts(
+        description="A real description.",
+        founders=["Alice"],
+        sector_keywords=["agents"],
+        last_funding_summary="Series B led by Foo.",
+        confidence=0.0,
+    )
+    assert _post_process(rich).confidence == 1.0
+
+    # Description only, nothing else → 0.5.
+    description_only = CompanyFacts(description="Only this.", confidence=1.0)
+    assert _post_process(description_only).confidence == 0.5
+
+    # Empty payload → 0.0 regardless of model claim.
+    empty = CompanyFacts(confidence=1.0)
+    assert _post_process(empty).confidence == 0.0

--- a/tests/test_firecrawl.py
+++ b/tests/test_firecrawl.py
@@ -1,0 +1,252 @@
+"""Tests for the Firecrawl enrichment client.
+
+All tests stub `FirecrawlClient._dispatch()` so the live SDK is never
+invoked. We mock the SDK shape rather than `httpx` because the SDK
+abstracts the HTTP layer for us; reaching into httpx would be fragile.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ai_sector_watch.extraction.firecrawl_client import (
+    DEFAULT_CREDITS_PER_CALL,
+    FirecrawlBudgetExceeded,
+    FirecrawlClient,
+    _post_process,
+    _sanitise,
+    firecrawl_enrich,
+)
+from ai_sector_watch.extraction.schema import CompanyFacts
+
+
+def _make_client(tmp_path, *, budget_credits: int = 200) -> FirecrawlClient:
+    return FirecrawlClient(budget_credits=budget_credits, cache_dir=tmp_path)
+
+
+SAMPLE_PAYLOAD: dict = {
+    "founded_year": 2020,
+    "description": "Relevance AI is an agent platform for the enterprise.",
+    "founders": ["Daniel Vassilev", "Jacky Koh"],
+    "city": "Sydney",
+    "country": "AU",
+    "sector_keywords": ["agents", "vector search", "RAG"],
+    "last_funding_summary": "Series B led by Bessemer in 2024.",
+    "confidence": 1.0,
+}
+
+
+def test_scrape_facts_returns_validated_company_facts(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+    calls: list[str] = []
+
+    def fake_dispatch(self, *, url, schema):
+        calls.append(url)
+        return dict(SAMPLE_PAYLOAD)
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    result = client.scrape_facts("https://relevanceai.com")
+    assert calls == ["https://relevanceai.com"]
+    assert isinstance(result.facts, CompanyFacts)
+    assert result.facts.founded_year == 2020
+    assert result.facts.founders == ["Daniel Vassilev", "Jacky Koh"]
+    assert result.facts.confidence == 1.0
+    assert result.cached is False
+    assert result.credits_used == DEFAULT_CREDITS_PER_CALL
+    assert client.stats.calls == 1
+    assert client.stats.credits_used == DEFAULT_CREDITS_PER_CALL
+
+
+def test_scrape_facts_caches_on_second_call(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+    calls = {"count": 0}
+
+    def fake_dispatch(self, *, url, schema):
+        calls["count"] += 1
+        return dict(SAMPLE_PAYLOAD)
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    a = client.scrape_facts("https://example.com")
+    b = client.scrape_facts("https://example.com")
+    assert calls["count"] == 1
+    assert a.cached is False
+    assert b.cached is True
+    assert client.stats.cache_hits == 1
+    # Cached call must NOT consume more budget.
+    assert client.stats.credits_used == DEFAULT_CREDITS_PER_CALL
+
+
+def test_budget_cap_blocks_further_scrapes(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path, budget_credits=DEFAULT_CREDITS_PER_CALL - 1)
+
+    def fake_dispatch(self, *, url, schema):
+        return dict(SAMPLE_PAYLOAD)
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    with pytest.raises(FirecrawlBudgetExceeded):
+        client.scrape_facts("https://example.com")
+    assert client.stats.calls == 0
+
+
+def test_budget_cap_lets_first_call_through_then_blocks(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path, budget_credits=DEFAULT_CREDITS_PER_CALL)
+
+    def fake_dispatch(self, *, url, schema):
+        return dict(SAMPLE_PAYLOAD)
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    client.scrape_facts("https://a.com")
+    with pytest.raises(FirecrawlBudgetExceeded):
+        client.scrape_facts("https://b.com")
+
+
+def test_scrape_failure_returns_empty_facts(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+
+    def boom(self, *, url, schema):
+        raise RuntimeError("network exploded")
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", boom)
+
+    result = client.scrape_facts("https://example.com")
+    assert result.facts.confidence == 0.0
+    assert result.facts.description is None
+    assert result.credits_used == 0
+    assert client.stats.calls == 1
+    assert client.stats.failures and "network exploded" in client.stats.failures[0]
+
+
+def test_em_dashes_in_description_are_sanitised(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+    payload = dict(SAMPLE_PAYLOAD)
+    payload["description"] = "Relevance AI is the agent platform — for the enterprise."
+    payload["last_funding_summary"] = "Series B – Bessemer led, 2024."
+
+    def fake_dispatch(self, *, url, schema):
+        return payload
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    facts = client.scrape_facts("https://example.com").facts
+    assert facts.description is not None
+    assert "—" not in facts.description
+    assert "–" not in facts.description
+    assert facts.last_funding_summary is not None
+    assert "—" not in facts.last_funding_summary
+    assert "–" not in facts.last_funding_summary
+
+
+def test_string_founded_year_coerced(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+    payload = dict(SAMPLE_PAYLOAD)
+    payload["founded_year"] = "2019"
+
+    def fake_dispatch(self, *, url, schema):
+        return payload
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    facts = client.scrape_facts("https://example.com").facts
+    assert facts.founded_year == 2019
+
+
+def test_string_list_field_coerced_to_list(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+    payload = dict(SAMPLE_PAYLOAD)
+    payload["founders"] = "Solo Founder"
+
+    def fake_dispatch(self, *, url, schema):
+        return payload
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    facts = client.scrape_facts("https://example.com").facts
+    assert facts.founders == ["Solo Founder"]
+
+
+def test_missing_confidence_is_derived(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+    payload = {
+        "description": "Just a description, no other fields.",
+        "founders": [],
+        "sector_keywords": [],
+    }
+
+    def fake_dispatch(self, *, url, schema):
+        return payload
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    facts = client.scrape_facts("https://example.com").facts
+    # Description only, no other populated fields: 0.5.
+    assert facts.confidence == 0.5
+
+
+def test_firecrawl_enrich_handles_missing_website(tmp_path) -> None:
+    client = _make_client(tmp_path)
+    facts = firecrawl_enrich(client, None)
+    assert facts.confidence == 0.0
+    assert client.stats.calls == 0
+
+    facts = firecrawl_enrich(client, "")
+    assert facts.confidence == 0.0
+    facts = firecrawl_enrich(client, "   ")
+    assert facts.confidence == 0.0
+    assert client.stats.calls == 0
+
+
+def test_firecrawl_enrich_passes_through_to_scrape(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+
+    def fake_dispatch(self, *, url, schema):
+        return dict(SAMPLE_PAYLOAD)
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    facts = firecrawl_enrich(client, "  https://example.com  ")
+    assert facts.confidence == 1.0
+    assert client.stats.calls == 1
+
+
+def test_cache_round_trip_persists_to_disk(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+
+    def fake_dispatch(self, *, url, schema):
+        return dict(SAMPLE_PAYLOAD)
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    client.scrape_facts("https://example.com")
+    cache_files = list(tmp_path.glob("*.json"))
+    assert len(cache_files) == 1
+    payload = json.loads(cache_files[0].read_text(encoding="utf-8"))
+    assert payload["facts"]["description"] == SAMPLE_PAYLOAD["description"]
+    assert payload["credits_used"] == DEFAULT_CREDITS_PER_CALL
+
+
+def test_sanitise_helpers() -> None:
+    assert _sanitise(None) is None
+    assert _sanitise("foo — bar") == "foo - bar"
+    assert _sanitise("foo – bar") == "foo - bar"
+    assert _sanitise("plain") == "plain"
+    # Empty string sanitises back to None.
+    assert _sanitise("") is None
+
+
+def test_post_process_strips_em_dashes_from_facts() -> None:
+    facts = CompanyFacts(
+        description="Lab — building agents.",
+        last_funding_summary="Series A — led by Foo.",
+        confidence=0.5,
+    )
+    cleaned = _post_process(facts)
+    assert cleaned.description is not None
+    assert "—" not in cleaned.description
+    assert cleaned.last_funding_summary is not None
+    assert "—" not in cleaned.last_funding_summary


### PR DESCRIPTION
Closes #33. Implements the spec in #14.

## Summary

- `FirecrawlClient` (`src/ai_sector_watch/extraction/firecrawl_client.py`) mirrors `ClaudeClient`: lazy auth on `FIRECRAWL_API_KEY`, on-disk cache at `data/local/firecrawl_cache/{hash}.json`, per-run credit cap via `FIRECRAWL_BUDGET_CREDITS_PER_RUN` (default 200), `FirecrawlBudgetExceeded` raised when the next call would push past the cap.
- `CompanyFacts` Pydantic schema added to `src/ai_sector_watch/extraction/schema.py` per spec.
- `firecrawl_enrich(client, website)` helper returns `CompanyFacts.empty()` (confidence=0) when no website is known or the scrape fails. SDK exceptions are recorded on `stats.failures` and never bubble.
- `pipeline/weekly.py` per-mention loop now: validate → firecrawl_enrich → classify (with `news_summary + facts.description + facts.sector_keywords` as context) → upsert with `founded_year` / `website` / `city` / `country` filled from facts when present.
- `CompanyValidation` extended with an optional `website` field (LLM extracts the URL when the article mentions it; null otherwise so enrichment is skipped).
- Pipeline JSON summary now reports `firecrawl_credits_used`, `firecrawl_calls`, `firecrawl_cache_hits`.
- Em dashes in `description` and `last_funding_summary` are sanitised on the way in so dashboard popup copy is safe.
- Confidence is recomputed client-side from populated fields rather than trusting the model. The first smoke run showed the model echoing the schema default (0.0) even when 4 fields came back populated, which would mask successful enrichment from downstream `confidence > 0` checks.

## Manual smoke check

Run against `https://relevanceai.com` with `FIRECRAWL_BUDGET_CREDITS_PER_RUN=200`. Two scrapes total (one before the confidence fix, one after); 10 credits combined, well under the 10-credit smoke ceiling and the 200-credit per-run cap.

```
budget_credits = 200
credits_per_call = 5

Scraping https://relevanceai.com ...

CompanyFacts:
{
  "founded_year": null,
  "description": "The best way to sell with AI: starts by assisting your team, evolves to driving your entire GTM strategy.",
  "founders": [],
  "city": null,
  "country": null,
  "sector_keywords": [
    "AI",
    "GTM strategy",
    "Sales integration",
    "Automation"
  ],
  "last_funding_summary": null,
  "confidence": 1.0
}

stats: calls=1 cache_hits=0 credits_used=5 failures=[]
```

Notes:
- Description is the company's homepage hero copy. Colon, not em dash.
- Sector keywords are sensible and richer than the news-snippet-only baseline.
- `founders`, `city`, `country`, `last_funding_summary` are null because the homepage does not state them. The about / team page is reachable but out of scope for v1; v2 can add `/map` to discover canonical pages.
- `confidence: 1.0` because description + sector_keywords are populated. If the scrape had returned an empty page, post-processing would have set confidence to 0 and the upsert would skip the enriched fields.

## Files touched

- `src/ai_sector_watch/extraction/firecrawl_client.py` (new)
- `src/ai_sector_watch/extraction/schema.py` (`CompanyFacts`, `CompanyValidation.website`)
- `src/ai_sector_watch/extraction/prompts.py` (validate prompt asks for `website`)
- `src/ai_sector_watch/pipeline/weekly.py` (enrichment wired in, stats surfaced)
- `scripts/run_weekly_pipeline.py` (firecrawl stats in JSON summary)
- `.env.template` (`FIRECRAWL_API_KEY`, `FIRECRAWL_BUDGET_CREDITS_PER_RUN`)
- `docs/sources.md` (new Enrichment section)
- `docs/operations.md` (cost-cap section extended)
- `pyproject.toml` (`firecrawl-py` core dep)
- `tests/test_firecrawl.py` (new, 15 tests; stubs `_dispatch` per spec)

## Test plan

- [x] `pytest -q` green (110 passed, 2 skipped for `SUPABASE_DB_URL`)
- [x] `ruff check .` and `black --check .` clean
- [x] Manual smoke check against https://relevanceai.com (output above)
- [ ] `--limit 2` live pipeline run: deferred. The live integration test path (`tests/test_pipeline_integration.py::test_pipeline_live_full_round_trip`) already exercises the orchestrator end-to-end with stubbed LLM + real Supabase; the new `firecrawl_client` parameter is None-safe (falls back to a default client whose `firecrawl_enrich` short-circuits on `validation.website=None`). Happy to run a `--limit 2` live pipeline pass once Supabase is loaded if you want, but that requires Supabase access this session does not have.

## Multi-agent coordination

- [x] Issue #33 self-assigned
- [x] Worktree at `AI-Sector-Watch-33-firecrawl-source-implement-enrichment-pe/`
- [x] Branch `claude-code/33-firecrawl-source-implement-enrichment-pe` pushed
- [x] Live operation (Firecrawl smoke check) signalled via this PR before running