### PR TITLE
Fix dashboard sidebar chrome

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -13,6 +13,7 @@ gatherUsageStats = false
 
 [client]
 toolbarMode = "minimal"
+showSidebarNavigation = false
 
 [server]
 # Serve dashboard/static/ at /app/static/ so og-image and favicon resolve

--- a/dashboard/components/theme.py
+++ b/dashboard/components/theme.py
@@ -25,6 +25,14 @@ _DESCRIPTION: str = (
     "Live ecosystem map of the Australian and New Zealand AI startup landscape, "
     "updated weekly by an automated agent pipeline."
 )
+_NAV_ITEMS: tuple[tuple[str, str], ...] = (
+    ("pages/0_About.py", "About"),
+    ("pages/1_Map.py", "Map"),
+    ("pages/2_Companies.py", "Companies"),
+    ("pages/3_News.py", "News"),
+    ("pages/4_Digest.py", "Digest"),
+    ("pages/90_Admin.py", "Admin"),
+)
 
 
 def _inject_styles() -> None:
@@ -106,6 +114,13 @@ def _render_wordmark() -> None:
     st.session_state[flag] = True
 
 
+def _render_sidebar_nav() -> None:
+    """Render the dashboard navigation in the intended order."""
+    with st.sidebar:
+        for page_path, label in _NAV_ITEMS:
+            st.page_link(page_path, label=label)
+
+
 def render_page_chrome(*, title: str, page_icon: str = "🌏") -> None:
     """Configure Streamlit page chrome for the current page.
 
@@ -126,4 +141,5 @@ def render_page_chrome(*, title: str, page_icon: str = "🌏") -> None:
     )
     _inject_styles()
     _inject_meta_tags(title=title)
+    _render_sidebar_nav()
     _render_wordmark()

--- a/dashboard/components/theme.py
+++ b/dashboard/components/theme.py
@@ -36,14 +36,10 @@ _NAV_ITEMS: tuple[tuple[str, str], ...] = (
 
 
 def _inject_styles() -> None:
-    """Inject ``styles.css`` once per Streamlit session."""
-    flag = "_aisw_styles_injected"
-    if st.session_state.get(flag):
-        return
+    """Inject ``styles.css`` for the current page render."""
     if _STYLES_PATH.exists():
         css = _STYLES_PATH.read_text(encoding="utf-8")
         st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
-        st.session_state[flag] = True
 
 
 def _inject_meta_tags(*, title: str) -> None:
@@ -101,9 +97,6 @@ def _inject_meta_tags(*, title: str) -> None:
 
 def _render_wordmark() -> None:
     """Render the AI Sector Watch wordmark at the top of every page."""
-    flag = "_aisw_wordmark_rendered"
-    if st.session_state.get(flag):
-        return
     st.markdown(
         '<div class="aisw-wordmark">'
         '<span class="aisw-wordmark__title">AI <em>Sector</em> Watch</span>'
@@ -111,7 +104,6 @@ def _render_wordmark() -> None:
         "</div>",
         unsafe_allow_html=True,
     )
-    st.session_state[flag] = True
 
 
 def _render_sidebar_nav() -> None:


### PR DESCRIPTION
## Summary

- Hide Streamlit's default sidebar navigation so the dashboard starts with About instead of the entrypoint script.
- Render the custom sidebar links from the shared page chrome helper in the intended order.
- Remove session-state guards around CSS and wordmark rendering so page chrome appears after cross-page navigation.

## Root cause

Streamlit always listed the entrypoint script before `dashboard/pages/`, so `0_About.py` alone did not make About first. The page chrome helper also stored CSS and wordmark render flags in session state, which suppressed the wordmark after navigating between pages.

## Validation

- `black --check .`
- `ruff check .`
- `pytest -q` with live Supabase tests skipped because `SUPABASE_DB_URL` is unset
- Browser smoke check on `http://localhost:8501/Map`: About appears first in the sidebar and the wordmark renders after navigation
