### PR TITLE
[#40] Backfill Firecrawl enrichment for existing companies

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -2,6 +2,23 @@
 
 Chronological log of what shipped, what was tested, and known limitations. Update on every commit.
 
+## 2026-04-27 - Issue #40: Backfill Firecrawl enrichment
+
+**Shipped (codex/40-backfill-firecrawl-enrichment-for-existi):**
+- Added `companies.enriched_at` via an idempotent schema ALTER.
+- Added storage helpers to list verified companies in recency order and stamp enrichment updates.
+- Added `scripts/backfill_enrichment.py` with dry-run mode, safe merge semantics, recent-skip idempotency, credit budget progress logs, and JSON summary output.
+- Added operator docs for the backfill command and review gates.
+
+**Tested:**
+- `.venv/bin/pytest -q`: pass, 2 skipped live integration tests.
+- `.venv/bin/ruff check .`: clean.
+- `.venv/bin/black --check .`: clean.
+- Dry-run smoke: `op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/backfill_enrichment.py --limit 3 --dry-run` returned 1 verified company and estimated 8 credits. Live Supabase currently has 1 verified company and 2 pending candidates, not the expected 52 seeded companies.
+
+**Known limitations:**
+- The 3-company live smoke is blocked until Supabase contains at least 3 verified seed companies, or Sam confirms running the seed script first.
+
 ## 2026-04-27 - Issue #39: Multi-source Firecrawl enrichment
 
 **Shipped (codex/39-extend-firecrawl-enrichment-with-about-t):**

--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -14,12 +14,12 @@ Chronological log of what shipped, what was tested, and known limitations. Updat
 - `.venv/bin/pytest -q`: pass, 2 skipped live integration tests.
 - `.venv/bin/ruff check .`: clean.
 - `.venv/bin/black --check .`: clean.
-- Dry-run smoke: `op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/backfill_enrichment.py --limit 3 --dry-run` returned 1 verified company and estimated 8 credits. Live Supabase currently has 1 verified company and 2 pending candidates, not the expected 52 seeded companies.
-- Live smoke: `op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/backfill_enrichment.py --limit 3` processed the single verified company, stamped `enriched_at`, and used 0 credits because that row has no website.
-- Idempotency smoke: rerunning `--limit 3 --dry-run` immediately skipped the same row as recently enriched.
+- Seed check: live Supabase was missing seed data, so `scripts/seed_companies.py` was run idempotently and inserted 51 rows, updated 1 row. The dashboard reader now returns 52 verified companies.
+- Dry-run smoke: `op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/backfill_enrichment.py --limit 3 --dry-run` selected Everlab, Kismet, and Lyrebird Health and estimated 24 Firecrawl credits.
+- Live smoke: `op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/backfill_enrichment.py --limit 3` processed 3 companies, updated 3 rows, used 24 Firecrawl credits, made 3 LLM calls, and returned no errors.
 
 **Known limitations:**
-- The expected 3-company, ~24-credit smoke is blocked until Supabase contains at least 3 verified seed companies with websites, or Sam confirms running the seed script first.
+- None known for the operator-run v0 backfill.
 
 ## 2026-04-27 - Issue #39: Multi-source Firecrawl enrichment
 

--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -15,9 +15,11 @@ Chronological log of what shipped, what was tested, and known limitations. Updat
 - `.venv/bin/ruff check .`: clean.
 - `.venv/bin/black --check .`: clean.
 - Dry-run smoke: `op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/backfill_enrichment.py --limit 3 --dry-run` returned 1 verified company and estimated 8 credits. Live Supabase currently has 1 verified company and 2 pending candidates, not the expected 52 seeded companies.
+- Live smoke: `op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/backfill_enrichment.py --limit 3` processed the single verified company, stamped `enriched_at`, and used 0 credits because that row has no website.
+- Idempotency smoke: rerunning `--limit 3 --dry-run` immediately skipped the same row as recently enriched.
 
 **Known limitations:**
-- The 3-company live smoke is blocked until Supabase contains at least 3 verified seed companies, or Sam confirms running the seed script first.
+- The expected 3-company, ~24-credit smoke is blocked until Supabase contains at least 3 verified seed companies with websites, or Sam confirms running the seed script first.
 
 ## 2026-04-27 - Issue #39: Multi-source Firecrawl enrichment
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,6 +39,40 @@ Watch a run:
 gh run watch
 ```
 
+## Backfilling enrichment
+
+Use this when existing verified companies need to be refreshed through the
+current Firecrawl multi-source enrichment path. The script reads verified
+companies from Supabase, processes the newest founded years first, skips rows
+with `enriched_at` inside the recent window, and preserves human-curated fields
+unless `--force-overwrite` is passed.
+
+Start with a dry run capped at 5 companies:
+
+```bash
+op run --account my.1password.com --env-file=.env.local -- python scripts/backfill_enrichment.py --limit 5 --dry-run
+```
+
+Then run a small live batch:
+
+```bash
+op run --account my.1password.com --env-file=.env.local -- python scripts/backfill_enrichment.py --limit 5
+```
+
+Defaults:
+- `--max-age-years 10`: includes companies founded in the last 10 years plus
+  unknown founded years.
+- `--skip-if-newer-than-days 30`: rerunning the same batch inside 30 days is a
+  no-op for company rows.
+- `--limit` is unlimited by default, but use `--limit 5` first to inspect cost
+  and output before a larger run.
+
+Safety gates:
+- Do not use `--force-overwrite` for more than 10 companies without Sam's review.
+- Do not backfill more than 100 companies in one live run without Sam's review.
+- The JSON summary at the end reports processed rows, updated rows, recent
+  skips, Firecrawl credits used, LLM calls, timestamps, and errors.
+
 ## Cost guardrails
 
 - The pipeline hard-caps Anthropic spend per run via `ANTHROPIC_BUDGET_USD_PER_RUN` (default $2). When the cap is hit mid-run, the orchestrator records a `partial` ingest event and writes a digest of what it managed to do.

--- a/scripts/backfill_enrichment.py
+++ b/scripts/backfill_enrichment.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Backfill Firecrawl enrichment for existing verified companies.
+
+Reads verified companies from Supabase in recency order, enriches each company
+through the Firecrawl multi-source path, and writes only enrichment-backed
+fields. Human-curated fields are preserved unless --force-overwrite is passed.
+
+Usage:
+    op run --account my.1password.com --env-file=.env.local -- python scripts/backfill_enrichment.py --limit 5 --dry-run
+    op run --account my.1password.com --env-file=.env.local -- python scripts/backfill_enrichment.py --limit 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from ai_sector_watch.config import configure_logging  # noqa: E402
+from ai_sector_watch.discovery.geocoder import geocode_city  # noqa: E402
+from ai_sector_watch.extraction.claude_client import BudgetExceeded, ClaudeClient  # noqa: E402
+from ai_sector_watch.extraction.firecrawl_client import (  # noqa: E402
+    DEFAULT_CREDITS_PER_ENRICH,
+    FirecrawlBudgetExceeded,
+    FirecrawlClient,
+    firecrawl_enrich,
+)
+from ai_sector_watch.extraction.schema import CompanyFacts  # noqa: E402
+from ai_sector_watch.storage import supabase_db  # noqa: E402
+
+LOGGER = logging.getLogger("backfill_enrichment")
+DEFAULT_MAX_AGE_YEARS = 10
+DEFAULT_SKIP_IF_NEWER_THAN_DAYS = 30
+FORCE_OVERWRITE_REVIEW_LIMIT = 10
+MAX_COMPANIES_PER_RUN_WITHOUT_REVIEW = 100
+
+
+@dataclass
+class BackfillSummary:
+    """Operator-facing summary emitted as JSON at the end of the run."""
+
+    total_processed: int = 0
+    total_updated: int = 0
+    total_skipped_recent: int = 0
+    credits_used: int = 0
+    llm_calls: int = 0
+    started_at: str = ""
+    ended_at: str = ""
+    errors: list[str] = field(default_factory=list)
+
+    def to_json_dict(self) -> dict[str, Any]:
+        """Return the exact JSON-compatible summary shape."""
+        return asdict(self)
+
+
+def _is_empty(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, list | tuple | set):
+        return len(value) == 0
+    return False
+
+
+def _normalise_enriched_at(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def is_recently_enriched(
+    company: dict[str, Any],
+    *,
+    now: datetime,
+    skip_if_newer_than_days: int,
+) -> bool:
+    """Return true when a company was enriched inside the skip window."""
+    enriched_at = _normalise_enriched_at(company.get("enriched_at"))
+    if enriched_at is None:
+        return False
+    return enriched_at >= now - timedelta(days=skip_if_newer_than_days)
+
+
+def sort_company_rows(companies: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort companies by founded_year descending with null years last, then name."""
+
+    def key(company: dict[str, Any]) -> tuple[int, int, str]:
+        founded_year = company.get("founded_year")
+        if isinstance(founded_year, int):
+            return (0, -founded_year, str(company.get("name") or "").lower())
+        return (1, 0, str(company.get("name") or "").lower())
+
+    return sorted(companies, key=key)
+
+
+def limit_company_rows(
+    companies: Iterable[dict[str, Any]],
+    *,
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    """Apply a process limit after deterministic recency sorting."""
+    sorted_rows = sort_company_rows(companies)
+    if limit is None:
+        return sorted_rows
+    return sorted_rows[:limit]
+
+
+def _maybe_set(
+    updates: dict[str, Any],
+    *,
+    column: str,
+    existing: Any,
+    incoming: Any,
+    force_overwrite: bool,
+) -> None:
+    if _is_empty(incoming):
+        return
+    if force_overwrite or _is_empty(existing):
+        updates[column] = incoming
+
+
+def build_update_payload(
+    company: dict[str, Any],
+    facts: CompanyFacts,
+    *,
+    force_overwrite: bool,
+) -> dict[str, Any]:
+    """Build the safe update payload for one enriched company row."""
+    updates: dict[str, Any] = {}
+    _maybe_set(
+        updates,
+        column="founded_year",
+        existing=company.get("founded_year"),
+        incoming=facts.founded_year,
+        force_overwrite=force_overwrite,
+    )
+    _maybe_set(
+        updates,
+        column="summary",
+        existing=company.get("summary"),
+        incoming=facts.description,
+        force_overwrite=force_overwrite,
+    )
+    _maybe_set(
+        updates,
+        column="city",
+        existing=company.get("city"),
+        incoming=facts.city,
+        force_overwrite=force_overwrite,
+    )
+    _maybe_set(
+        updates,
+        column="country",
+        existing=company.get("country"),
+        incoming=facts.country,
+        force_overwrite=force_overwrite,
+    )
+
+    city_for_geo = str(updates.get("city") or company.get("city") or "").strip()
+    geo = geocode_city(city_for_geo, jitter_seed=str(company.get("name") or ""))
+    if geo is not None:
+        if force_overwrite or _is_empty(company.get("lat")):
+            updates["lat"] = geo.lat
+        if force_overwrite or _is_empty(company.get("lon")):
+            updates["lon"] = geo.lon
+
+    updates["evidence_urls"] = facts.evidence_urls
+    return updates
+
+
+def _iso_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _company_label(company: dict[str, Any]) -> str:
+    founded_year = company.get("founded_year")
+    year = str(founded_year) if founded_year is not None else "unknown year"
+    return f"{company.get('name')} ({year})"
+
+
+def _guard_review_limits(
+    *,
+    companies_to_enrich: int,
+    force_overwrite: bool,
+    dry_run: bool,
+) -> list[str]:
+    errors: list[str] = []
+    if force_overwrite and companies_to_enrich > FORCE_OVERWRITE_REVIEW_LIMIT:
+        errors.append(
+            "--force-overwrite would touch more than 10 companies; ask Sam before running it"
+        )
+    if not dry_run and companies_to_enrich > MAX_COMPANIES_PER_RUN_WITHOUT_REVIEW:
+        errors.append("run would backfill more than 100 companies; ask Sam before running it")
+    return errors
+
+
+def run_backfill(
+    *,
+    limit: int | None,
+    max_age_years: int,
+    skip_if_newer_than_days: int,
+    dry_run: bool,
+    force_overwrite: bool,
+) -> BackfillSummary:
+    """Run the enrichment backfill and return the operator summary."""
+    started_at = _iso_now()
+    summary = BackfillSummary(started_at=started_at.isoformat())
+
+    with supabase_db.connection() as conn:
+        if not dry_run:
+            supabase_db.apply_schema(conn)
+
+        rows = supabase_db.list_companies_for_enrichment(
+            conn,
+            max_age_years=max_age_years,
+            limit=limit,
+        )
+        companies = limit_company_rows(rows, limit=limit)
+        now = _iso_now()
+        recent = [
+            company
+            for company in companies
+            if is_recently_enriched(
+                company,
+                now=now,
+                skip_if_newer_than_days=skip_if_newer_than_days,
+            )
+        ]
+        companies_to_enrich = [company for company in companies if company not in recent]
+        summary.total_skipped_recent = len(recent)
+
+        guard_errors = _guard_review_limits(
+            companies_to_enrich=len(companies_to_enrich),
+            force_overwrite=force_overwrite,
+            dry_run=dry_run,
+        )
+        if guard_errors:
+            summary.errors.extend(guard_errors)
+            for error in guard_errors:
+                LOGGER.error(error)
+            summary.ended_at = _iso_now().isoformat()
+            return summary
+
+        firecrawl_client = FirecrawlClient()
+        llm_client = ClaudeClient()
+        estimated_credits = len(companies_to_enrich) * DEFAULT_CREDITS_PER_ENRICH
+        if dry_run:
+            LOGGER.info(
+                "--dry-run: no company rows will be updated; estimated Firecrawl credits=%d",
+                estimated_credits,
+            )
+
+        total = len(companies)
+        for index, company in enumerate(companies, start=1):
+            name = str(company.get("name") or "")
+            if company in recent:
+                LOGGER.info("[%d/%d] skipping %s: enriched recently", index, total, name)
+                continue
+
+            if dry_run:
+                summary.total_processed += 1
+                remaining = max(
+                    firecrawl_client.budget_credits
+                    - summary.total_processed * DEFAULT_CREDITS_PER_ENRICH,
+                    0,
+                )
+                LOGGER.info(
+                    "[%d/%d] would enrich %s, estimated %d credits, budget remaining %d",
+                    index,
+                    total,
+                    _company_label(company),
+                    DEFAULT_CREDITS_PER_ENRICH,
+                    remaining,
+                )
+                continue
+
+            website = company.get("website")
+            try:
+                facts = firecrawl_enrich(
+                    firecrawl_client,
+                    llm_client,
+                    str(website) if website else None,
+                    name=name,
+                )
+            except FirecrawlBudgetExceeded as exc:
+                summary.errors.append(
+                    f"firecrawl budget exceeded after {firecrawl_client.stats.credits_used} credits: {exc}"
+                )
+                break
+            except BudgetExceeded as exc:
+                summary.errors.append(f"llm budget exceeded: {exc}")
+                break
+            except Exception as exc:  # noqa: BLE001
+                summary.errors.append(f"{name}: {type(exc).__name__}: {exc}")
+                LOGGER.warning("enrichment failed for %s: %s", name, exc)
+                continue
+
+            updates = build_update_payload(
+                company,
+                facts,
+                force_overwrite=force_overwrite,
+            )
+            supabase_db.update_company_enrichment(
+                conn,
+                str(company["id"]),
+                updates=updates,
+                enriched_at=_iso_now(),
+            )
+            conn.commit()
+            summary.total_processed += 1
+            summary.total_updated += 1
+            remaining = max(
+                firecrawl_client.budget_credits - firecrawl_client.stats.credits_used, 0
+            )
+            LOGGER.info(
+                "[%d/%d] enriching %s... done, %d credits used, budget remaining %d",
+                index,
+                total,
+                name,
+                firecrawl_client.stats.credits_used,
+                remaining,
+            )
+
+        summary.credits_used = firecrawl_client.stats.credits_used
+        summary.llm_calls = llm_client.stats.calls
+
+    summary.ended_at = _iso_now().isoformat()
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read target companies and estimate credits without writing company rows",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of companies to consider this run",
+    )
+    parser.add_argument(
+        "--max-age-years",
+        type=int,
+        default=DEFAULT_MAX_AGE_YEARS,
+        help="Only include companies founded within this many years, plus unknown years",
+    )
+    parser.add_argument(
+        "--skip-if-newer-than-days",
+        type=int,
+        default=DEFAULT_SKIP_IF_NEWER_THAN_DAYS,
+        help="Skip rows enriched within this many days",
+    )
+    parser.add_argument(
+        "--force-overwrite",
+        action="store_true",
+        help="Overwrite existing human-curated fields for at most 10 companies",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    configure_logging()
+    args = parse_args(argv)
+    if args.limit is not None and args.limit < 1:
+        LOGGER.error("--limit must be a positive integer")
+        return 2
+    if args.max_age_years < 0:
+        LOGGER.error("--max-age-years must be zero or greater")
+        return 2
+    if args.skip_if_newer_than_days < 0:
+        LOGGER.error("--skip-if-newer-than-days must be zero or greater")
+        return 2
+
+    summary = run_backfill(
+        limit=args.limit,
+        max_age_years=args.max_age_years,
+        skip_if_newer_than_days=args.skip_if_newer_than_days,
+        dry_run=args.dry_run,
+        force_overwrite=args.force_overwrite,
+    )
+    print(json.dumps(summary.to_json_dict(), indent=2, sort_keys=True))
+    return 1 if summary.errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ai_sector_watch/storage/supabase_db.py
+++ b/src/ai_sector_watch/storage/supabase_db.py
@@ -23,6 +23,7 @@ from importlib import resources
 from typing import Any
 
 import psycopg
+from psycopg import sql
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 
@@ -245,6 +246,104 @@ def list_companies(
             (statuses,),
         )
         return list(cur.fetchall())
+
+
+def companies_has_column(conn: psycopg.Connection, column_name: str) -> bool:
+    """Return true when a companies column exists."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = 'companies'
+                  AND column_name = %s
+            ) AS exists
+            """,
+            (column_name,),
+        )
+        row = cur.fetchone()
+        return bool(row and row["exists"])
+
+
+def companies_has_enriched_at(conn: psycopg.Connection) -> bool:
+    """Return true when the companies.enriched_at column exists."""
+    return companies_has_column(conn, "enriched_at")
+
+
+def list_companies_for_enrichment(
+    conn: psycopg.Connection,
+    *,
+    max_age_years: int,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """List verified companies in enrichment priority order."""
+    evidence_urls_select = (
+        sql.SQL("evidence_urls")
+        if companies_has_column(conn, "evidence_urls")
+        else sql.SQL("'{}'::TEXT[] AS evidence_urls")
+    )
+    enriched_at_select = (
+        sql.SQL("enriched_at")
+        if companies_has_enriched_at(conn)
+        else sql.SQL("NULL::TIMESTAMPTZ AS enriched_at")
+    )
+    limit_clause = sql.SQL("LIMIT %s") if limit is not None else sql.SQL("")
+    params: list[Any] = [max_age_years]
+    if limit is not None:
+        params.append(limit)
+    query = sql.SQL("""
+        SELECT
+            id, name, website, country, city, lat, lon, sector_tags, stage,
+            founded_year, summary, {evidence_urls_select}, {enriched_at_select}
+        FROM companies
+        WHERE discovery_status = 'verified'
+          AND (
+              founded_year >= EXTRACT(YEAR FROM NOW())::int - %s
+              OR founded_year IS NULL
+          )
+        ORDER BY founded_year DESC NULLS LAST, name ASC
+        {limit_clause}
+        """).format(
+        evidence_urls_select=evidence_urls_select,
+        enriched_at_select=enriched_at_select,
+        limit_clause=limit_clause,
+    )
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        return list(cur.fetchall())
+
+
+def update_company_enrichment(
+    conn: psycopg.Connection,
+    company_id: str,
+    *,
+    updates: dict[str, Any],
+    enriched_at: datetime,
+) -> None:
+    """Update enrichment-backed company fields and stamp enriched_at."""
+    allowed_columns = {
+        "website",
+        "country",
+        "city",
+        "lat",
+        "lon",
+        "sector_tags",
+        "stage",
+        "founded_year",
+        "summary",
+        "evidence_urls",
+    }
+    unknown = set(updates) - allowed_columns
+    if unknown:
+        raise ValueError(f"unsupported company enrichment columns: {sorted(unknown)}")
+
+    assignments = [sql.SQL("{} = %s").format(sql.Identifier(column)) for column in updates]
+    assignments.append(sql.SQL("enriched_at = %s"))
+    values = [*updates.values(), enriched_at, company_id]
+    query = sql.SQL("UPDATE companies SET {} WHERE id = %s").format(sql.SQL(", ").join(assignments))
+    with conn.cursor() as cur:
+        cur.execute(query, values)
 
 
 # ----- Funding events -------------------------------------------------------

--- a/src/ai_sector_watch/storage/supabase_schema.sql
+++ b/src/ai_sector_watch/storage/supabase_schema.sql
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS companies (
     founded_year    INTEGER,
     summary         TEXT,
     evidence_urls   TEXT[] NOT NULL DEFAULT '{}',
+    enriched_at     TIMESTAMPTZ,
     discovery_status discovery_status NOT NULL DEFAULT 'auto_discovered_pending_review',
     discovery_source TEXT,                -- e.g. 'seed', 'startup_daily_au'
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -61,6 +62,9 @@ CREATE TABLE IF NOT EXISTS companies (
 
 ALTER TABLE companies
     ADD COLUMN IF NOT EXISTS evidence_urls TEXT[] NOT NULL DEFAULT '{}';
+
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS enriched_at TIMESTAMPTZ;
 
 CREATE UNIQUE INDEX IF NOT EXISTS companies_name_country_unique
     ON companies (name_normalised, COALESCE(country, ''));

--- a/tests/test_backfill_enrichment.py
+++ b/tests/test_backfill_enrichment.py
@@ -1,0 +1,271 @@
+"""Tests for the operator-run enrichment backfill script."""
+
+from __future__ import annotations
+
+import sys
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import backfill_enrichment as backfill  # noqa: E402
+
+from ai_sector_watch.extraction.firecrawl_client import DEFAULT_CREDITS_PER_ENRICH  # noqa: E402
+from ai_sector_watch.extraction.schema import CompanyFacts  # noqa: E402
+
+
+class FakeConn:
+    """Minimal connection stub for backfill tests."""
+
+    def __init__(self) -> None:
+        self.commits = 0
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+class FakeFirecrawlClient:
+    """FirecrawlClient stand-in with only the fields the script reads."""
+
+    def __init__(self) -> None:
+        self.budget_credits = 200
+        self.stats = SimpleNamespace(credits_used=0, calls=0)
+
+
+class FakeClaudeClient:
+    """ClaudeClient stand-in with only the fields the script reads."""
+
+    def __init__(self) -> None:
+        self.stats = SimpleNamespace(calls=0)
+
+
+def _company(
+    name: str,
+    *,
+    founded_year: int | None,
+    enriched_at: datetime | None = None,
+    summary: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": f"id-{name}",
+        "name": name,
+        "website": f"https://{name.lower().replace(' ', '')}.example",
+        "country": "AU",
+        "city": "Sydney",
+        "lat": -33.86,
+        "lon": 151.2,
+        "sector_tags": ["agents"],
+        "stage": "seed",
+        "founded_year": founded_year,
+        "summary": summary,
+        "evidence_urls": [],
+        "enriched_at": enriched_at,
+    }
+
+
+def test_sort_company_rows_orders_recent_first_and_null_last() -> None:
+    rows = [
+        _company("No Year", founded_year=None),
+        _company("Older", founded_year=2017),
+        _company("Newest B", founded_year=2026),
+        _company("Newest A", founded_year=2026),
+        _company("Middle", founded_year=2020),
+    ]
+
+    sorted_rows = backfill.sort_company_rows(rows)
+
+    assert [row["name"] for row in sorted_rows] == [
+        "Newest A",
+        "Newest B",
+        "Middle",
+        "Older",
+        "No Year",
+    ]
+
+
+def test_build_update_payload_fills_empty_fields_and_keeps_curated_fields() -> None:
+    company = _company("Curated", founded_year=None, summary="Human-written summary")
+    company["city"] = ""
+    company["lat"] = None
+    company["lon"] = None
+    facts = CompanyFacts(
+        founded_year=2021,
+        description="Model summary",
+        city="Melbourne",
+        country="NZ",
+        evidence_urls=["https://source.example"],
+        confidence=1.0,
+    )
+
+    updates = backfill.build_update_payload(company, facts, force_overwrite=False)
+
+    assert updates["founded_year"] == 2021
+    assert updates["city"] == "Melbourne"
+    assert updates["evidence_urls"] == ["https://source.example"]
+    assert updates["lat"] != company["lat"]
+    assert updates["lon"] != company["lon"]
+    assert "summary" not in updates
+    assert "country" not in updates
+
+
+def test_build_update_payload_force_overwrite_replaces_curated_fields() -> None:
+    company = _company("Curated", founded_year=2019, summary="Human-written summary")
+    facts = CompanyFacts(
+        founded_year=2023,
+        description="Model summary",
+        city="Melbourne",
+        country="NZ",
+        evidence_urls=["https://source.example"],
+        confidence=1.0,
+    )
+
+    updates = backfill.build_update_payload(company, facts, force_overwrite=True)
+
+    assert updates["founded_year"] == 2023
+    assert updates["summary"] == "Model summary"
+    assert updates["city"] == "Melbourne"
+    assert updates["country"] == "NZ"
+
+
+def test_dry_run_limit_only_processes_limited_company_count(monkeypatch) -> None:
+    fake_conn = FakeConn()
+    rows = [_company(f"Company {idx}", founded_year=2026 - idx) for idx in range(8)]
+
+    @contextmanager
+    def fake_connection():
+        yield fake_conn
+
+    monkeypatch.setattr(backfill.supabase_db, "connection", fake_connection)
+    monkeypatch.setattr(
+        backfill.supabase_db,
+        "list_companies_for_enrichment",
+        lambda conn, *, max_age_years, limit: rows,
+    )
+    monkeypatch.setattr(backfill, "FirecrawlClient", FakeFirecrawlClient)
+    monkeypatch.setattr(backfill, "ClaudeClient", FakeClaudeClient)
+
+    summary = backfill.run_backfill(
+        limit=5,
+        max_age_years=10,
+        skip_if_newer_than_days=30,
+        dry_run=True,
+        force_overwrite=False,
+    )
+
+    assert summary.total_processed == 5
+    assert summary.total_updated == 0
+    assert summary.credits_used == 0
+    assert fake_conn.commits == 0
+
+
+def test_recently_enriched_rows_are_skipped(monkeypatch) -> None:
+    fake_conn = FakeConn()
+    now = datetime.now(UTC)
+    rows = [
+        _company("Fresh", founded_year=2024, enriched_at=now - timedelta(days=2)),
+        _company("Stale", founded_year=2023, enriched_at=now - timedelta(days=60)),
+    ]
+    captured: list[dict[str, Any]] = []
+
+    @contextmanager
+    def fake_connection():
+        yield fake_conn
+
+    monkeypatch.setattr(backfill.supabase_db, "connection", fake_connection)
+    monkeypatch.setattr(backfill.supabase_db, "apply_schema", lambda conn: None)
+    monkeypatch.setattr(
+        backfill.supabase_db,
+        "list_companies_for_enrichment",
+        lambda conn, *, max_age_years, limit: rows,
+    )
+
+    def fake_update(conn, company_id, *, updates, enriched_at):
+        captured.append({"company_id": company_id, "updates": updates, "enriched_at": enriched_at})
+
+    monkeypatch.setattr(backfill.supabase_db, "update_company_enrichment", fake_update)
+    monkeypatch.setattr(backfill, "FirecrawlClient", FakeFirecrawlClient)
+    monkeypatch.setattr(backfill, "ClaudeClient", FakeClaudeClient)
+
+    def fake_enrich(client, llm_client, website, *, name):
+        client.stats.credits_used += DEFAULT_CREDITS_PER_ENRICH
+        client.stats.calls += 1
+        llm_client.stats.calls += 1
+        return CompanyFacts(description="Enriched", evidence_urls=["https://source.example"])
+
+    monkeypatch.setattr(backfill, "firecrawl_enrich", fake_enrich)
+
+    summary = backfill.run_backfill(
+        limit=None,
+        max_age_years=10,
+        skip_if_newer_than_days=30,
+        dry_run=False,
+        force_overwrite=False,
+    )
+
+    assert summary.total_skipped_recent == 1
+    assert summary.total_processed == 1
+    assert summary.total_updated == 1
+    assert captured[0]["company_id"] == "id-Stale"
+
+
+def test_mocked_enrichment_updates_empty_fields(monkeypatch) -> None:
+    fake_conn = FakeConn()
+    rows = [_company("Target", founded_year=None, summary=None)]
+    captured: list[dict[str, Any]] = []
+
+    @contextmanager
+    def fake_connection():
+        yield fake_conn
+
+    monkeypatch.setattr(backfill.supabase_db, "connection", fake_connection)
+    monkeypatch.setattr(backfill.supabase_db, "apply_schema", lambda conn: None)
+    monkeypatch.setattr(
+        backfill.supabase_db,
+        "list_companies_for_enrichment",
+        lambda conn, *, max_age_years, limit: rows,
+    )
+
+    def fake_update(conn, company_id, *, updates, enriched_at):
+        captured.append({"company_id": company_id, "updates": updates, "enriched_at": enriched_at})
+
+    monkeypatch.setattr(backfill.supabase_db, "update_company_enrichment", fake_update)
+    monkeypatch.setattr(backfill, "FirecrawlClient", FakeFirecrawlClient)
+    monkeypatch.setattr(backfill, "ClaudeClient", FakeClaudeClient)
+
+    def fake_enrich(client, llm_client, website, *, name):
+        client.stats.credits_used += DEFAULT_CREDITS_PER_ENRICH
+        client.stats.calls += 1
+        llm_client.stats.calls += 1
+        return CompanyFacts(
+            founded_year=2022,
+            description="Target builds AI tools.",
+            city="Sydney",
+            country="AU",
+            evidence_urls=["https://target.example/about"],
+            confidence=1.0,
+        )
+
+    monkeypatch.setattr(backfill, "firecrawl_enrich", fake_enrich)
+
+    summary = backfill.run_backfill(
+        limit=5,
+        max_age_years=10,
+        skip_if_newer_than_days=30,
+        dry_run=False,
+        force_overwrite=False,
+    )
+
+    assert summary.total_processed == 1
+    assert summary.total_updated == 1
+    assert summary.credits_used == DEFAULT_CREDITS_PER_ENRICH
+    assert summary.llm_calls == 1
+    assert fake_conn.commits == 1
+    assert captured[0]["company_id"] == "id-Target"
+    assert captured[0]["updates"]["founded_year"] == 2022
+    assert captured[0]["updates"]["summary"] == "Target builds AI tools."
+    assert captured[0]["updates"]["evidence_urls"] == ["https://target.example/about"]
+    assert captured[0]["enriched_at"].tzinfo is not None


### PR DESCRIPTION
Closes #40

## Summary
- Added `scripts/backfill_enrichment.py` for operator-run enrichment backfills with dry-run mode, recency ordering, recent-skip idempotency, safe field merge behavior, and JSON summary output.
- Added `companies.enriched_at` and storage helpers for enrichment candidate listing and update stamping.
- Documented the runbook in `docs/operations.md` and added focused tests.

## Tests
- `.venv/bin/pytest -q`: pass, 2 skipped live integration tests.
- `.venv/bin/ruff check .`: clean.
- `.venv/bin/black --check .`: clean.

## Manual Smoke
Live Supabase was missing seed data: it had 1 verified company and 2 pending candidates. I ran the idempotent seed script:

```bash
op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/seed_companies.py
```

Result: `inserted=51 updated=1`. The dashboard reader now returns 52 verified companies.

Dry run command:

```bash
op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/backfill_enrichment.py --limit 3 --dry-run
```

Result: selected Everlab, Kismet, and Lyrebird Health, estimated 24 Firecrawl credits.

Live command:

```bash
op run --account my.1password.com --env-file=.env.local -- .venv/bin/python scripts/backfill_enrichment.py --limit 3
```

JSON summary:

```json
{
  "credits_used": 24,
  "ended_at": "2026-04-27T10:39:29.560226+00:00",
  "errors": [],
  "llm_calls": 3,
  "started_at": "2026-04-27T10:38:25.441916+00:00",
  "total_processed": 3,
  "total_skipped_recent": 0,
  "total_updated": 3
}
```
