### PR TITLE
[#43] Address Codex review backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,11 +73,11 @@ These are hard rules. If a task seems to require breaking one, stop and ask.
 - Conventional Commits format: `<type>(<scope>): <subject>` (e.g. `feat(dashboard): add filters`). Subject line ≤ 72 chars.
 - Commit hooks reject AI-tool attribution (`Co-Authored-By: Claude ...`, `Generated with ...`). Don't add those.
 - Each commit either runs green tests or documents the manual smoke check that was performed.
-- Update `PROJECT_PROGRESS.md` in the same commit.
+- Update `PROJECT_PROGRESS.md` in the same commit only for milestones.
 
 ### Branching
 
-- Trunk-based. Work directly on `main` for now (single-operator project). Feature branches when a change is non-trivial enough to want a pre-merge review.
+- Trunk-based through per-issue worktrees. Do not commit directly on `main`; branch from `origin/main` with `scripts/start_issue.sh`.
 
 ### Style
 

--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -1,6 +1,6 @@
 # Project Progress
 
-Chronological log of what shipped, what was tested, and known limitations. Update on every commit.
+Chronological log of milestones: public features, closed Now/Next issues, live changes, and public breakages. For routine fixes, the PR body is the record.
 
 ## 2026-04-27 - Issue #40: Backfill Firecrawl enrichment
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ Full detail in [`AGENTS.md`](AGENTS.md). Short version:
 - All secrets via 1Password (`op run --account my.1password.com --env-file=.env.local -- ...`). Bare values never in files; `.env.local` is gitignored; only `.env.template` (with `op://` references) is committed.
 - Idempotent operations: every upsert keys on a stable hash; the pipeline is safe to rerun.
 - No em dashes in any user-facing output (digest, dashboard copy, popups). Use a colon, comma, or " - " instead.
-- Every commit updates `PROJECT_PROGRESS.md`.
+- Update `PROJECT_PROGRESS.md` only for milestones: closing a Now/Next issue,
+  shipping a public feature, or documenting a public breakage.
 - The public map only shows `discovery_status = 'verified'`. Auto-discovered candidates wait in the admin queue.
 
 ## Disclaimer

--- a/dashboard/pages/0_About.py
+++ b/dashboard/pages/0_About.py
@@ -23,7 +23,7 @@ LINKEDIN_URL = "https://www.linkedin.com/in/samclifton"
 def _render_architecture() -> None:
     """Render the pipeline diagram, falling back to ASCII if the SVG is unavailable."""
     if ARCHITECTURE_PATH.exists():
-        st.image(str(ARCHITECTURE_PATH), width="stretch")
+        st.image(str(ARCHITECTURE_PATH), use_container_width=True)
         return
 
     st.code(

--- a/dashboard/pages/4_Digest.py
+++ b/dashboard/pages/4_Digest.py
@@ -13,7 +13,11 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from ai_sector_watch.config import get_config  # noqa: E402
-from ai_sector_watch.storage.data_source import LlmSpendSummary, get_data_source  # noqa: E402
+from ai_sector_watch.storage.data_source import (  # noqa: E402
+    LlmSpendSummary,
+    get_data_source,
+    safe_llm_spend_summary,
+)
 from dashboard.components.footer import render_footer  # noqa: E402
 from dashboard.components.theme import render_page_chrome  # noqa: E402
 
@@ -39,7 +43,11 @@ def main() -> None:
     st.caption("Auto-generated summaries written by the weekly pipeline. Latest first.")
 
     source = get_data_source()
-    _render_spend_metrics(source.llm_spend_summary())
+    spend_summary, spend_error = safe_llm_spend_summary(source)
+    if spend_error is not None:
+        st.warning("Spend metrics unavailable; showing saved digests.")
+    else:
+        _render_spend_metrics(spend_summary)
 
     digest_dir = get_config().digest_output_dir
     digest_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/backfill_enrichment.py
+++ b/scripts/backfill_enrichment.py
@@ -133,6 +133,21 @@ def _maybe_set(
         updates[column] = incoming
 
 
+def _has_enrichment_signal(facts: CompanyFacts) -> bool:
+    """Return true when Firecrawl produced at least one usable fact."""
+    values = (
+        facts.founded_year,
+        facts.description,
+        facts.founders,
+        facts.city,
+        facts.country,
+        facts.sector_keywords,
+        facts.last_funding_summary,
+        facts.evidence_urls,
+    )
+    return any(not _is_empty(value) for value in values)
+
+
 def build_update_payload(
     company: dict[str, Any],
     facts: CompanyFacts,
@@ -141,6 +156,7 @@ def build_update_payload(
 ) -> dict[str, Any]:
     """Build the safe update payload for one enriched company row."""
     updates: dict[str, Any] = {}
+    has_fact_signal = _has_enrichment_signal(facts)
     _maybe_set(
         updates,
         column="founded_year",
@@ -170,15 +186,17 @@ def build_update_payload(
         force_overwrite=force_overwrite,
     )
 
-    city_for_geo = str(updates.get("city") or company.get("city") or "").strip()
-    geo = geocode_city(city_for_geo, jitter_seed=str(company.get("name") or ""))
-    if geo is not None:
-        if force_overwrite or _is_empty(company.get("lat")):
-            updates["lat"] = geo.lat
-        if force_overwrite or _is_empty(company.get("lon")):
-            updates["lon"] = geo.lon
+    if has_fact_signal:
+        city_for_geo = str(updates.get("city") or company.get("city") or "").strip()
+        geo = geocode_city(city_for_geo, jitter_seed=str(company.get("name") or ""))
+        if geo is not None:
+            if force_overwrite or _is_empty(company.get("lat")):
+                updates["lat"] = geo.lat
+            if force_overwrite or _is_empty(company.get("lon")):
+                updates["lon"] = geo.lon
 
-    updates["evidence_urls"] = facts.evidence_urls
+    if facts.evidence_urls:
+        updates["evidence_urls"] = facts.evidence_urls
     return updates
 
 
@@ -314,6 +332,15 @@ def run_backfill(
                 facts,
                 force_overwrite=force_overwrite,
             )
+            summary.total_processed += 1
+            if not updates:
+                LOGGER.info(
+                    "[%d/%d] enriching %s... no usable updates, skipping write",
+                    index,
+                    total,
+                    name,
+                )
+                continue
             supabase_db.update_company_enrichment(
                 conn,
                 str(company["id"]),
@@ -321,7 +348,6 @@ def run_backfill(
                 enriched_at=_iso_now(),
             )
             conn.commit()
-            summary.total_processed += 1
             summary.total_updated += 1
             remaining = max(
                 firecrawl_client.budget_credits - firecrawl_client.stats.credits_used, 0

--- a/scripts/start_issue.sh
+++ b/scripts/start_issue.sh
@@ -159,6 +159,7 @@ PROJECT_OWNER="SCClifton"
 PROJECT_ID="PVT_kwHOCnSDOc4BVz2x"
 WORKFLOW_FIELD_ID="PVTSSF_lAHOCnSDOc4BVz2xzhRNAXY"
 WORKFLOW_IN_PROGRESS="e00b541b"
+PROJECT_CARD_MOVED=0
 
 set +e
 ITEM_ID=$(
@@ -172,12 +173,18 @@ if [[ -n "$ITEM_ID" && "$ITEM_ID" != "null" ]]; then
     --project-id "$PROJECT_ID" \
     --field-id "$WORKFLOW_FIELD_ID" \
     --single-select-option-id "$WORKFLOW_IN_PROGRESS" >/dev/null 2>&1 \
-    && echo "    Project Workflow set to In Progress" \
+    && { echo "    Project Workflow set to In Progress"; PROJECT_CARD_MOVED=1; } \
     || echo "    (could not move Project card; do it manually)"
 else
   echo "    Issue not on Project board yet; skipping Workflow move"
 fi
 set -e
+
+if [[ "$PROJECT_CARD_MOVED" == "1" ]]; then
+  PROJECT_CARD_NOTE='Project card has already been moved to "In Progress".'
+else
+  PROJECT_CARD_NOTE='Move the Project card to "In Progress" if it is on the board.'
+fi
 
 # Step 7: print next steps.
 cat <<EOF
@@ -197,7 +204,7 @@ Make your first commit, then open a Draft PR:
 Run secret-bearing commands with the explicit 1Password account:
   op run --account my.1password.com --env-file=.env.local -- <your command>
 
-Project card has already been moved to "In Progress".
+$PROJECT_CARD_NOTE
 
 When ready for review, mark the PR as ready and ping Sam.
 

--- a/src/ai_sector_watch/extraction/firecrawl_client.py
+++ b/src/ai_sector_watch/extraction/firecrawl_client.py
@@ -147,7 +147,8 @@ def _is_blocked_news_url(url: str) -> bool:
 
 
 def _candidate_page_matches(url: str, title: str | None) -> bool:
-    haystack = " ".join([url, title or ""]).lower()
+    parsed = urlparse(_normalise_url(url))
+    haystack = " ".join([parsed.path, title or ""]).lower()
     return any(keyword in haystack for keyword in COMPANY_PAGE_KEYWORDS)
 
 
@@ -408,6 +409,10 @@ class FirecrawlClient:
                 cleaned["confidence"] = float(confidence)
             except ValueError:
                 cleaned["confidence"] = _derive_confidence(cleaned)
+        if not isinstance(cleaned.get("confidence"), int | float) or not (
+            0.0 <= float(cleaned["confidence"]) <= 1.0
+        ):
+            cleaned["confidence"] = _derive_confidence(cleaned)
 
         return CompanyFacts.model_validate(cleaned)
 

--- a/src/ai_sector_watch/pipeline/weekly.py
+++ b/src/ai_sector_watch/pipeline/weekly.py
@@ -285,26 +285,29 @@ def run_weekly_pipeline(
             )
             result.items_new += 1
             if news_class.kind == "funding" and linked_ids:
-                primary_company_id = linked_ids[0]
-                primary_company_name = company_names_by_id.get(primary_company_id)
-                if primary_company_name:
-                    try:
-                        funding = _extract_funding(client, item, primary_company_name)
-                    except BudgetExceeded as exc:
-                        result.errors.append(f"budget exceeded: {exc}")
-                        break
-                    if funding.has_funding_event:
-                        supabase_db.upsert_funding_event(
-                            conn,
-                            company_id=primary_company_id,
-                            announced_on=funding.announced_on,
-                            stage=_clean_funding_stage(funding.stage),
-                            amount_usd=funding.amount_usd,
-                            currency_raw=funding.currency_raw,
-                            lead_investor=funding.lead_investor,
-                            investors=funding.investors,
-                            source_url=item.url,
-                        )
+                try:
+                    funding_match = _extract_first_funding_event(
+                        client,
+                        item,
+                        company_ids=linked_ids,
+                        company_names_by_id=company_names_by_id,
+                    )
+                except BudgetExceeded as exc:
+                    result.errors.append(f"budget exceeded: {exc}")
+                    break
+                if funding_match is not None:
+                    company_id, funding = funding_match
+                    supabase_db.upsert_funding_event(
+                        conn,
+                        company_id=company_id,
+                        announced_on=funding.announced_on,
+                        stage=_clean_funding_stage(funding.stage),
+                        amount_usd=funding.amount_usd,
+                        currency_raw=funding.currency_raw,
+                        lead_investor=funding.lead_investor,
+                        investors=funding.investors,
+                        source_url=item.url,
+                    )
 
         # 5. Audit row per run.
         supabase_db.insert_ingest_event(
@@ -389,6 +392,24 @@ def _extract_funding(client: ClaudeClient, item: RawItem, company_name: str) -> 
         max_tokens=384,
     )
     return response.parsed  # type: ignore[return-value]
+
+
+def _extract_first_funding_event(
+    client: ClaudeClient,
+    item: RawItem,
+    *,
+    company_ids: list[str],
+    company_names_by_id: dict[str, str],
+) -> tuple[str, FundingExtraction] | None:
+    """Return the linked company whose funding extraction confirms the event."""
+    for company_id in company_ids:
+        company_name = company_names_by_id.get(company_id)
+        if not company_name:
+            continue
+        funding = _extract_funding(client, item, company_name)
+        if funding.has_funding_event:
+            return company_id, funding
+    return None
 
 
 def _dedupe_ids(ids: list[str]) -> list[str]:

--- a/src/ai_sector_watch/sources/sitemap.py
+++ b/src/ai_sector_watch/sources/sitemap.py
@@ -98,4 +98,7 @@ def _node_text(
 def _parse_datetime(value: str | None) -> datetime | None:
     if not value:
         return None
-    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError:
+        return None

--- a/src/ai_sector_watch/storage/data_source.py
+++ b/src/ai_sector_watch/storage/data_source.py
@@ -13,6 +13,7 @@ code never has to know which source it is reading from.
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 from datetime import date, datetime
@@ -27,6 +28,7 @@ from ai_sector_watch.discovery.geocoder import geocode_city
 from ai_sector_watch.storage import supabase_db
 
 SEED_PATH = REPO_ROOT / "data" / "seed" / "companies.yaml"
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -262,6 +264,15 @@ def _company_from_row(r: dict) -> Company:
         discovery_source=r.get("discovery_source"),
         latest_funding_event=latest_funding_event,
     )
+
+
+def safe_llm_spend_summary(source: DataSource) -> tuple[LlmSpendSummary | None, Exception | None]:
+    """Return spend summary without letting a backend failure break dashboard rendering."""
+    try:
+        return source.llm_spend_summary(), None
+    except Exception as exc:  # noqa: BLE001
+        LOGGER.warning("llm spend summary unavailable from %s: %s", source.backend, exc)
+        return None, exc
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backfill_enrichment.py
+++ b/tests/test_backfill_enrichment.py
@@ -131,6 +131,21 @@ def test_build_update_payload_force_overwrite_replaces_curated_fields() -> None:
     assert updates["country"] == "NZ"
 
 
+def test_build_update_payload_empty_facts_do_not_clear_existing_evidence() -> None:
+    company = _company("Curated", founded_year=2019, summary="Human-written summary")
+    company["evidence_urls"] = ["https://existing.example"]
+    company["lat"] = None
+    company["lon"] = None
+
+    updates = backfill.build_update_payload(
+        company,
+        CompanyFacts.empty(),
+        force_overwrite=False,
+    )
+
+    assert updates == {}
+
+
 def test_dry_run_limit_only_processes_limited_company_count(monkeypatch) -> None:
     fake_conn = FakeConn()
     rows = [_company(f"Company {idx}", founded_year=2026 - idx) for idx in range(8)]
@@ -210,6 +225,52 @@ def test_recently_enriched_rows_are_skipped(monkeypatch) -> None:
     assert summary.total_processed == 1
     assert summary.total_updated == 1
     assert captured[0]["company_id"] == "id-Stale"
+
+
+def test_empty_enrichment_result_does_not_write_or_stamp(monkeypatch) -> None:
+    fake_conn = FakeConn()
+    rows = [_company("Target", founded_year=2023, summary="Existing summary")]
+    rows[0]["evidence_urls"] = ["https://existing.example"]
+    captured: list[dict[str, Any]] = []
+
+    @contextmanager
+    def fake_connection():
+        yield fake_conn
+
+    monkeypatch.setattr(backfill.supabase_db, "connection", fake_connection)
+    monkeypatch.setattr(backfill.supabase_db, "apply_schema", lambda conn: None)
+    monkeypatch.setattr(
+        backfill.supabase_db,
+        "list_companies_for_enrichment",
+        lambda conn, *, max_age_years, limit: rows,
+    )
+
+    def fake_update(conn, company_id, *, updates, enriched_at):
+        captured.append({"company_id": company_id, "updates": updates, "enriched_at": enriched_at})
+
+    monkeypatch.setattr(backfill.supabase_db, "update_company_enrichment", fake_update)
+    monkeypatch.setattr(backfill, "FirecrawlClient", FakeFirecrawlClient)
+    monkeypatch.setattr(backfill, "ClaudeClient", FakeClaudeClient)
+
+    def fake_enrich(client, llm_client, website, *, name):
+        client.stats.credits_used += DEFAULT_CREDITS_PER_ENRICH
+        client.stats.calls += 1
+        return CompanyFacts.empty()
+
+    monkeypatch.setattr(backfill, "firecrawl_enrich", fake_enrich)
+
+    summary = backfill.run_backfill(
+        limit=None,
+        max_age_years=10,
+        skip_if_newer_than_days=30,
+        dry_run=False,
+        force_overwrite=False,
+    )
+
+    assert summary.total_processed == 1
+    assert summary.total_updated == 0
+    assert fake_conn.commits == 0
+    assert captured == []
 
 
 def test_mocked_enrichment_updates_empty_fields(monkeypatch) -> None:

--- a/tests/test_data_source.py
+++ b/tests/test_data_source.py
@@ -13,6 +13,7 @@ from ai_sector_watch.storage.data_source import (
     SupabaseSource,
     YamlSource,
     get_data_source,
+    safe_llm_spend_summary,
 )
 
 
@@ -140,6 +141,25 @@ def test_supabase_source_returns_no_llm_spend_when_empty(
     monkeypatch.setattr(supabase_db, "connection", fake_connection)
 
     assert SupabaseSource().llm_spend_summary() is None
+
+
+def test_safe_llm_spend_summary_catches_backend_failure() -> None:
+    class BoomSource:
+        backend = "boom"
+
+        def list_companies(self, *, statuses=("verified",)):
+            return []
+
+        def recent_news(self, *, limit=50):
+            return []
+
+        def llm_spend_summary(self):
+            raise RuntimeError("database unavailable")
+
+    summary, error = safe_llm_spend_summary(BoomSource())
+
+    assert summary is None
+    assert isinstance(error, RuntimeError)
 
 
 def test_factory_returns_yaml_when_supabase_url_unset(monkeypatch) -> None:

--- a/tests/test_firecrawl.py
+++ b/tests/test_firecrawl.py
@@ -18,6 +18,7 @@ from ai_sector_watch.extraction.firecrawl_client import (
     FirecrawlBudgetExceeded,
     FirecrawlClient,
     MarkdownDocument,
+    _candidate_page_matches,
     _post_process,
     _sanitise,
     firecrawl_enrich,
@@ -208,6 +209,22 @@ def test_missing_confidence_is_derived(tmp_path, monkeypatch) -> None:
     assert facts.confidence == 0.5
 
 
+def test_invalid_numeric_confidence_is_recomputed_before_validation(tmp_path, monkeypatch) -> None:
+    client = _make_client(tmp_path)
+    payload = dict(SAMPLE_PAYLOAD)
+    payload["confidence"] = 2.0
+
+    def fake_dispatch(self, *, url, schema):
+        return payload
+
+    monkeypatch.setattr(FirecrawlClient, "_dispatch", fake_dispatch)
+
+    facts = client.scrape_facts("https://example.com").facts
+    assert facts.description == SAMPLE_PAYLOAD["description"]
+    assert facts.founders == SAMPLE_PAYLOAD["founders"]
+    assert facts.confidence == 1.0
+
+
 def test_firecrawl_enrich_handles_missing_website(tmp_path) -> None:
     client = _make_client(tmp_path)
     llm = FakeClaudeClient()
@@ -292,6 +309,12 @@ def test_find_company_pages_filters_keywords_domain_and_caps(tmp_path, monkeypat
         "https://example.com/company",
     ]
     assert client.stats.credits_used == 1
+
+
+def test_candidate_page_matching_ignores_domain_keywords() -> None:
+    assert _candidate_page_matches("https://example.com/about", None)
+    assert _candidate_page_matches("https://example.com/careers", "Leadership")
+    assert not _candidate_page_matches("https://team.example.com/careers", "Careers")
 
 
 def test_fetch_company_news_searches_last_year_and_scrapes_top_results(

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -31,6 +31,7 @@ from ai_sector_watch.extraction.schema import (
     FundingExtraction,
     NewsClassification,
 )
+from ai_sector_watch.pipeline import weekly
 from ai_sector_watch.pipeline.weekly import run_weekly_pipeline
 from ai_sector_watch.sources.base import RawItem, SourceBase
 
@@ -209,6 +210,44 @@ def test_write_digest_handles_empty_run(tmp_path) -> None:
     text = path.read_text(encoding="utf-8")
     assert "Sources attempted: 0" in text
     assert "## Relevant news" not in text
+
+
+def test_extract_first_funding_event_uses_company_with_confirmed_event(monkeypatch) -> None:
+    item = RawItem(
+        source_slug="fake_source",
+        url="https://example.com/funding",
+        title="FundedCo raises seed from InvestorCo",
+        summary="InvestorCo backed FundedCo's new seed round.",
+        published_at=datetime(2026, 4, 21, tzinfo=UTC),
+    )
+    calls: list[str] = []
+
+    def fake_extract_funding(client, raw_item, company_name):
+        calls.append(company_name)
+        return FundingExtraction(
+            has_funding_event=company_name == "FundedCo",
+            announced_on=date(2026, 4, 21),
+            stage="seed",
+            amount_usd=5_000_000 if company_name == "FundedCo" else None,
+            currency_raw="USD 5M" if company_name == "FundedCo" else None,
+            lead_investor="InvestorCo" if company_name == "FundedCo" else None,
+            investors=["InvestorCo"] if company_name == "FundedCo" else [],
+        )
+
+    monkeypatch.setattr(weekly, "_extract_funding", fake_extract_funding)
+
+    match = weekly._extract_first_funding_event(
+        object(),  # type: ignore[arg-type]
+        item,
+        company_ids=["investor-id", "funded-id"],
+        company_names_by_id={"investor-id": "InvestorCo", "funded-id": "FundedCo"},
+    )
+
+    assert match is not None
+    company_id, funding = match
+    assert company_id == "funded-id"
+    assert funding.has_funding_event is True
+    assert calls == ["InvestorCo", "FundedCo"]
 
 
 # ----- Live-DB path -------------------------------------------------------

--- a/tests/test_rss_sources.py
+++ b/tests/test_rss_sources.py
@@ -84,6 +84,30 @@ def test_parse_google_news_sitemap_bytes_extracts_items() -> None:
     assert items[0].raw["publication"] == "Capital Brief"
 
 
+def test_parse_google_news_sitemap_bytes_tolerates_bad_publication_date() -> None:
+    body = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+            xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+      <url>
+        <loc>https://www.capitalbrief.com/article/bad-date</loc>
+        <news:news>
+          <news:publication>
+            <news:name>Capital Brief</news:name>
+            <news:language>en</news:language>
+          </news:publication>
+          <news:publication_date>not-a-date</news:publication_date>
+          <news:title>Bad date should not drop the item</news:title>
+        </news:news>
+      </url>
+    </urlset>
+    """
+
+    items = parse_google_news_sitemap_bytes(body, slug="capital_brief")
+
+    assert len(items) == 1
+    assert items[0].published_at is None
+
+
 def test_capital_brief_factory_uses_news_sitemap() -> None:
     source = capital_brief()
     assert source.slug == "capital_brief"


### PR DESCRIPTION
## Summary

Fixes the actionable automated review backlog from recent merged PRs in one cleanup branch.

## Why

Several automated review threads remained unresolved after later work landed. Most were small but real correctness risks around enrichment writes, funding attribution, dashboard resilience, source parsing, and workflow messaging.

## Changes

- Hardened enrichment backfill writes so empty enrichment results do not clear evidence, stamp `enriched_at`, commit, or inflate `total_updated`.
- Tightened Firecrawl enrichment: company-page matching now ignores domain keywords, and invalid numeric confidence is recomputed before schema validation.
- Changed funding extraction to test linked companies until the funding event is confirmed, instead of assuming `linked_ids[0]` is the funded company.
- Kept dashboard pages resilient to supported Streamlit versions and spend-metric DB failures.
- Made sitemap date parsing tolerant per item and fixed `start_issue.sh` project-card success messaging.
- Aligned README, AGENTS, and PROJECT_PROGRESS wording around per-issue worktrees and milestone-only progress updates.

## Review backlog audit

Fixed here:

- PR #42: https://github.com/SCClifton/ai-sector-watch/pull/42#discussion_r3146648668
- PR #42: https://github.com/SCClifton/ai-sector-watch/pull/42#discussion_r3146648675
- PR #41: https://github.com/SCClifton/ai-sector-watch/pull/41#discussion_r3146560162
- PR #37: https://github.com/SCClifton/ai-sector-watch/pull/37#discussion_r3146277725
- PR #35: https://github.com/SCClifton/ai-sector-watch/pull/35#discussion_r3146190183
- PR #24: https://github.com/SCClifton/ai-sector-watch/pull/24#discussion_r3145034802
- PR #23: https://github.com/SCClifton/ai-sector-watch/pull/23#discussion_r3144984333
- PR #22: https://github.com/SCClifton/ai-sector-watch/pull/22#discussion_r3144913245
- PR #13: https://github.com/SCClifton/ai-sector-watch/pull/13#discussion_r3144730533

Already fixed before this PR:

- PR #34: https://github.com/SCClifton/ai-sector-watch/pull/34#discussion_r3146109123
- PR #34: https://github.com/SCClifton/ai-sector-watch/pull/34#discussion_r3146109133
- PR #10: https://github.com/SCClifton/ai-sector-watch/pull/10#discussion_r3144668530

No old merged PR review threads were replied to or resolved.

## Test plan

- [x] `PYTHONPATH=src .venv/bin/pytest tests/test_backfill_enrichment.py tests/test_firecrawl.py tests/test_pipeline_integration.py tests/test_rss_sources.py tests/test_data_source.py -q` passes, with the expected live Supabase skip.
- [x] `PYTHONPATH=src .venv/bin/pytest -q` passes, with the expected live Supabase skips.
- [x] `PYTHONPATH=src .venv/bin/ruff check .` passes.
- [x] `PYTHONPATH=src .venv/bin/black --check .` passes.
- [x] `bash -n scripts/start_issue.sh scripts/finish_issue.sh` passes.
- [x] No live Supabase writes, live Firecrawl runs, or LLM-spending smoke tests were run.

## Multi-agent coordination

- [x] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md).
- [x] I am the assignee on the linked issue.
- [x] Branch is named `codex/43-address-codex-review-backlog`.
- [x] Rebased on latest `main` before worktree creation.

## Screenshots

Not captured. The dashboard changes are compatibility and failure-resilience fixes, covered by tests and static checks.

## Related issues

Closes #43
