### PR TITLE
[#49] [bug] Enable Streamlit WebSockets on Azure

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -2,6 +2,21 @@
 
 Chronological log of milestones: public features, closed Now/Next issues, live changes, and public breakages. For routine fixes, the PR body is the record.
 
+## 2026-04-28 - Issue #49: Azure WebSockets for Streamlit
+
+**Shipped (codex/49-bug-enable-streamlit-websockets-on-azure):**
+- Documented the required Azure App Service WebSocket setting for the Streamlit browser session.
+- Added deployment smoke checks that verify `webSocketsEnabled` before relying on HTTP health.
+- Enabled WebSockets on the live Azure Web App after the issue was opened.
+
+**Tested:**
+- `az webapp config show -g ai-sector-watch -n ai-sector-watch --query webSocketsEnabled -o tsv`: `true`.
+- `curl -fsS https://aimap.cliftonfamily.co/_stcore/health`: `ok`.
+- Browser smoke: `/`, `/Map`, and `/Companies` render dashboard content.
+
+**Known limitations:**
+- None known.
+
 ## 2026-04-27 - Issue #40: Backfill Firecrawl enrichment
 
 **Shipped (codex/40-backfill-firecrawl-enrichment-for-existi):**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,6 +36,13 @@ az webapp config appsettings set \
   --name "$APP" \
   --settings WEBSITES_PORT=8000
 
+# Streamlit needs a persistent WebSocket connection for the browser session.
+# Without this, health checks can pass while visitors see only the empty shell.
+az webapp config set \
+  --resource-group "$RG" \
+  --name "$APP" \
+  --web-sockets-enabled true
+
 # 5. App settings (mirror from 1Password manually for v0)
 ANTHROPIC_API_KEY=$(op read "op://Private/Anthropic API Key/credential")
 SUPABASE_DB_URL=$(op read "op://Private/Supabase AI Sector Watch/connection_string")
@@ -131,8 +138,12 @@ az webapp config ssl bind \
 ## Smoke checks
 
 ```bash
+az webapp config show -g ai-sector-watch -n ai-sector-watch \
+  --query webSocketsEnabled -o tsv                 # expect true
 curl -I https://aimap.cliftonfamily.co               # expect HTTP/2 200, valid cert
 curl -fsS https://aimap.cliftonfamily.co/_stcore/health
+# Browser smoke: open /, /Map, and /Companies. Expect rendered headings, not
+# just the blank Streamlit shell.
 gh workflow run weekly.yml -f limit=5
 gh run watch
 ```

--- a/tests/test_deployment_docs.py
+++ b/tests/test_deployment_docs.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_deployment_docs_require_streamlit_websockets() -> None:
+    """Azure runbook must enable the WebSocket transport Streamlit needs."""
+    deployment = (REPO_ROOT / "docs" / "deployment.md").read_text(encoding="utf-8")
+
+    assert "--web-sockets-enabled true" in deployment
+    assert "--query webSocketsEnabled" in deployment


### PR DESCRIPTION
Closes #49

## Summary
- enabled WebSockets on the live Azure App Service
- documented the required WebSocket setting in the deployment runbook
- added a deployment-doc test to keep the setting in the runbook

## Verification
- `.venv/bin/pytest -q`
- `.venv/bin/ruff check .`
- `.venv/bin/black --check .`
- `az webapp config show -g ai-sector-watch -n ai-sector-watch --query webSocketsEnabled -o tsv` -> `true`
- `curl -fsS https://aimap.cliftonfamily.co/_stcore/health` -> `ok`
- browser smoke rendered `/`, `/Map`, and `/Companies` headings