### PR TITLE
[#50] [feature] Polish public dashboard first-run UX

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -17,6 +17,23 @@ Chronological log of milestones: public features, closed Now/Next issues, live c
 **Known limitations:**
 - None known.
 
+## 2026-04-28 - Issue #50: Public dashboard first-run UX
+
+**Shipped (codex/50-feature-polish-public-dashboard-first-ru):**
+- Added explicit Reset controls to the Map and Companies filter sidebars.
+- Separated Admin under an Operations group in the sidebar navigation.
+- Moved Digest pipeline spend metrics behind a lower collapsed expander so saved digests stay primary.
+- Added focused tests for the navigation grouping and filter reset defaults.
+
+**Tested:**
+- `.venv/bin/pytest -q`: pass, 2 skipped live integration tests.
+- `.venv/bin/ruff check .`: clean.
+- `.venv/bin/black --check .`: clean.
+- Local browser smoke on `http://127.0.0.1:8510`: Map and Companies render Reset controls, Digest renders Pipeline spend below the public content, and Admin appears under Operations.
+
+**Known limitations:**
+- None known.
+
 ## 2026-04-27 - Issue #40: Backfill Firecrawl enrichment
 
 **Shipped (codex/40-backfill-firecrawl-enrichment-for-existi):**

--- a/dashboard/components/filters.py
+++ b/dashboard/components/filters.py
@@ -11,6 +11,7 @@ from ai_sector_watch.discovery.taxonomy import SECTORS, STAGES, get_sector
 from ai_sector_watch.storage.data_source import Company
 
 _SECTOR_LABEL_BY_TAG = {s.tag: s.label for s in SECTORS}
+_FILTER_FIELDS = ("sectors", "stages", "countries", "founded_year", "name_query")
 
 
 @dataclass(frozen=True)
@@ -59,51 +60,104 @@ def derive_meta(companies: list[Company]) -> FilterMeta:
     return FilterMeta(countries=tuple(countries))
 
 
-def render_sidebar(meta: FilterMeta, *, default_countries: tuple[str, ...]) -> FilterState:
+def filter_widget_keys(*, key_prefix: str) -> dict[str, str]:
+    """Return stable Streamlit widget keys for a filter group."""
+    return {field: f"{key_prefix}_{field}" for field in _FILTER_FIELDS}
+
+
+def default_filter_values(
+    meta: FilterMeta, *, default_countries: tuple[str, ...], key_prefix: str = "filters"
+) -> dict[str, object]:
+    """Return default widget values for a filter group."""
+    keys = filter_widget_keys(key_prefix=key_prefix)
+    founded_min, founded_max = _year_bounds(meta)
+    valid_defaults = [c for c in default_countries if c in meta.countries]
+    return {
+        keys["sectors"]: [],
+        keys["stages"]: [],
+        keys["countries"]: valid_defaults,
+        keys["founded_year"]: (int(founded_min), int(founded_max)),
+        keys["name_query"]: "",
+    }
+
+
+def _year_bounds(meta: FilterMeta) -> tuple[int, int]:
+    """Return slider-safe year bounds."""
+    founded_min, founded_max = meta.founded_min, meta.founded_max
+    if founded_min == founded_max:
+        founded_min, founded_max = founded_min - 1, founded_max
+    return int(founded_min), int(founded_max)
+
+
+def _advance_filter_reset(nonce_key: str) -> None:
+    """Advance the widget key suffix so filters rebuild from defaults."""
+    st.session_state[nonce_key] = int(st.session_state.get(nonce_key, 0)) + 1
+
+
+def render_sidebar(
+    meta: FilterMeta, *, default_countries: tuple[str, ...], key_prefix: str = "filters"
+) -> FilterState:
     """Render the filter widgets in the sidebar, return a FilterState."""
+    nonce_key = f"{key_prefix}_reset_nonce"
+    st.session_state.setdefault(nonce_key, 0)
+    widget_prefix = f"{key_prefix}_{st.session_state[nonce_key]}"
+    keys = filter_widget_keys(key_prefix=widget_prefix)
+    defaults = default_filter_values(
+        meta,
+        default_countries=default_countries,
+        key_prefix=widget_prefix,
+    )
+    for key, value in defaults.items():
+        st.session_state.setdefault(key, value)
+    founded_min, founded_max = _year_bounds(meta)
     with st.sidebar:
-        st.header("Filters")
+        header_cols = st.columns([1.3, 1])
+        header_cols[0].header("Filters")
+        header_cols[1].button(
+            "Reset",
+            key=f"{key_prefix}_reset_filters",
+            on_click=_advance_filter_reset,
+            args=(nonce_key,),
+        )
 
         sector_tags = [s.tag for s in SECTORS]
         sectors = st.multiselect(
             "Sector",
             options=sector_tags,
-            default=[],
             format_func=lambda t: _SECTOR_LABEL_BY_TAG.get(t, t),
             help="Pick one or more sectors. Empty = all sectors.",
+            key=keys["sectors"],
         )
 
         stages = st.multiselect(
             "Stage",
             options=list(STAGES),
-            default=[],
             help="Empty = all stages.",
+            key=keys["stages"],
         )
 
-        valid_defaults = [c for c in default_countries if c in meta.countries]
         countries = st.multiselect(
             "Country",
             options=list(meta.countries),
-            default=valid_defaults,
             help="Default: ANZ. Clear to include everywhere.",
+            key=keys["countries"],
         )
 
-        founded_min, founded_max = meta.founded_min, meta.founded_max
-        if founded_min == founded_max:
-            founded_min, founded_max = founded_min - 1, founded_max
         year_range = st.slider(
             "Founded year",
-            min_value=int(founded_min),
-            max_value=int(founded_max),
-            value=(int(founded_min), int(founded_max)),
+            min_value=founded_min,
+            max_value=founded_max,
             step=1,
+            key=keys["founded_year"],
         )
 
-        name_query = st.text_input("Search name", value="", placeholder="e.g. Marqo")
-
-        st.caption(
-            "Filters apply to the map and the table below it. " "Reset by clearing each control."
+        name_query = st.text_input(
+            "Search name",
+            placeholder="e.g. Marqo",
+            key=keys["name_query"],
         )
+
+        st.caption("Filters apply to the current page and reset from the button above.")
 
     return FilterState(
         sectors=tuple(sectors),

--- a/dashboard/components/theme.py
+++ b/dashboard/components/theme.py
@@ -26,15 +26,15 @@ _DESCRIPTION: str = (
     "Live ecosystem map of the Australian and New Zealand AI startup landscape, "
     "updated weekly by an automated agent pipeline."
 )
-_NAV_ITEMS: tuple[tuple[str, str], ...] = (
+_PUBLIC_NAV_ITEMS: tuple[tuple[str, str], ...] = (
     ("/", "Overview"),
     ("/About", "About"),
     ("/Map", "Map"),
     ("/Companies", "Companies"),
     ("/News", "News"),
     ("/Digest", "Digest"),
-    ("/Admin", "Admin"),
 )
+_OPERATIONS_NAV_ITEMS: tuple[tuple[str, str], ...] = (("/Admin", "Admin"),)
 
 
 def _inject_styles() -> None:
@@ -114,18 +114,31 @@ def _active_nav_label(title: str) -> str:
 
 def _sidebar_nav_html(*, active_label: str) -> str:
     """Render the project navigation as stable HTML instead of Streamlit's native nav."""
-    items: list[str] = []
-    for href, label in _NAV_ITEMS:
+    public_items: list[str] = []
+    operations_items: list[str] = []
+    for href, label in _PUBLIC_NAV_ITEMS:
         active_attr = ' aria-current="page"' if label == active_label else ""
         class_name = "aisw-sidebar-nav__link"
         if label == active_label:
             class_name += " aisw-sidebar-nav__link--active"
-        items.append(
+        public_items.append(
+            f'<a class="{class_name}" href="{escape(href)}"{active_attr}>' f"{escape(label)}</a>"
+        )
+    for href, label in _OPERATIONS_NAV_ITEMS:
+        active_attr = ' aria-current="page"' if label == active_label else ""
+        class_name = "aisw-sidebar-nav__link aisw-sidebar-nav__link--operations"
+        if label == active_label:
+            class_name += " aisw-sidebar-nav__link--active"
+        operations_items.append(
             f'<a class="{class_name}" href="{escape(href)}"{active_attr}>' f"{escape(label)}</a>"
         )
     return (
         '<nav class="aisw-sidebar-nav" aria-label="Dashboard navigation">'
-        '<div class="aisw-sidebar-nav__eyebrow">Dashboard</div>' + "".join(items) + "</nav>"
+        '<div class="aisw-sidebar-nav__eyebrow">Dashboard</div>'
+        + "".join(public_items)
+        + '<div class="aisw-sidebar-nav__section">Operations</div>'
+        + "".join(operations_items)
+        + "</nav>"
     )
 
 

--- a/dashboard/pages/1_Map.py
+++ b/dashboard/pages/1_Map.py
@@ -42,7 +42,7 @@ def main() -> None:
         )
 
     meta = derive_meta(all_companies)
-    state = render_sidebar(meta, default_countries=("AU", "NZ"))
+    state = render_sidebar(meta, default_countries=("AU", "NZ"), key_prefix="map_filters")
     render_sector_legend()
     companies = apply_filters(all_companies, state)
     on_map, off_map = split_geocoded(companies)

--- a/dashboard/pages/2_Companies.py
+++ b/dashboard/pages/2_Companies.py
@@ -39,7 +39,7 @@ def main() -> None:
         )
 
     meta = derive_meta(all_companies)
-    state = render_sidebar(meta, default_countries=("AU", "NZ"))
+    state = render_sidebar(meta, default_countries=("AU", "NZ"), key_prefix="company_filters")
     companies = apply_filters(all_companies, state)
 
     cols = st.columns(2)

--- a/dashboard/pages/4_Digest.py
+++ b/dashboard/pages/4_Digest.py
@@ -38,16 +38,21 @@ def _render_spend_metrics(summary: LlmSpendSummary | None) -> None:
     cols[1].metric("avg per run", _format_usd(summary.average_usd))
 
 
+def _render_spend_panel(summary: LlmSpendSummary | None, error: Exception | None) -> None:
+    """Render internal pipeline spend below the public digest content."""
+    with st.expander("Pipeline spend", expanded=False):
+        if error is not None:
+            st.warning("Spend metrics unavailable; showing saved digests.")
+            return
+        _render_spend_metrics(summary)
+
+
 def main() -> None:
     st.title("Weekly digest")
     st.caption("Auto-generated summaries written by the weekly pipeline. Latest first.")
 
     source = get_data_source()
     spend_summary, spend_error = safe_llm_spend_summary(source)
-    if spend_error is not None:
-        st.warning("Spend metrics unavailable; showing saved digests.")
-    else:
-        _render_spend_metrics(spend_summary)
 
     digest_dir = get_config().digest_output_dir
     digest_dir.mkdir(parents=True, exist_ok=True)
@@ -60,6 +65,7 @@ def main() -> None:
             "(Sydney time): a short, sourced summary of the week's ANZ AI "
             "activity."
         )
+        _render_spend_panel(spend_summary, spend_error)
         render_footer()
         return
 
@@ -67,6 +73,7 @@ def main() -> None:
     pick = st.selectbox("Digest", options=options, index=0)
     chosen = next(f for f in files if f.stem == pick)
     st.markdown(chosen.read_text(encoding="utf-8"))
+    _render_spend_panel(spend_summary, spend_error)
 
     render_footer()
 

--- a/dashboard/static/styles.css
+++ b/dashboard/static/styles.css
@@ -122,6 +122,17 @@ code, pre, kbd, samp {
   text-transform: uppercase;
 }
 
+.aisw-sidebar-nav__section {
+  margin: 1.1rem 0 0.35rem 0.25rem;
+  padding-top: 0.95rem;
+  border-top: 1px solid var(--aisw-border);
+  color: var(--aisw-text-subtle);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
 .aisw-sidebar-nav__link,
 .aisw-sidebar-nav__link:visited {
   display: block;
@@ -149,6 +160,10 @@ code, pre, kbd, samp {
   background: var(--aisw-accent-soft);
   border-color: rgba(244, 183, 64, 0.42);
   color: var(--aisw-accent-hover) !important;
+}
+
+.aisw-sidebar-nav__link--operations {
+  color: var(--aisw-text-subtle) !important;
 }
 
 /* Headings: editorial hierarchy, deliberate spacing */

--- a/tests/test_dashboard_theme.py
+++ b/tests/test_dashboard_theme.py
@@ -24,6 +24,15 @@ def test_sidebar_nav_marks_one_current_page() -> None:
     assert "aisw-sidebar-nav__link--active" in html
 
 
+def test_sidebar_nav_separates_admin_from_public_pages() -> None:
+    html = _sidebar_nav_html(active_label="Admin")
+
+    assert "Operations" in html
+    assert 'href="/Admin"' in html
+    assert "aisw-sidebar-nav__link--operations" in html
+    assert html.count('aria-current="page"') == 1
+
+
 def test_docker_image_includes_streamlit_config() -> None:
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
     deploy = (REPO_ROOT / ".github" / "workflows" / "deploy.yml").read_text(encoding="utf-8")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,7 +7,9 @@ from dashboard.components.filters import (
     FilterState,
     apply_filters,
     companies_to_table_rows,
+    default_filter_values,
     derive_meta,
+    filter_widget_keys,
 )
 
 
@@ -100,6 +102,27 @@ def test_derive_meta_returns_country_set_and_year_bounds() -> None:
     assert meta.countries == ("AU", "NZ")
     assert meta.founded_min == 2018
     assert meta.founded_max == 2024
+
+
+def test_default_filter_values_match_sidebar_reset_contract() -> None:
+    meta = derive_meta(
+        [
+            _make(name="A", country="AU", founded_year=2018),
+            _make(name="B", country="NZ", founded_year=2024),
+        ]
+    )
+    keys = filter_widget_keys(key_prefix="map_filters")
+    defaults = default_filter_values(
+        meta,
+        default_countries=("AU", "NZ"),
+        key_prefix="map_filters",
+    )
+
+    assert defaults[keys["sectors"]] == []
+    assert defaults[keys["stages"]] == []
+    assert defaults[keys["countries"]] == ["AU", "NZ"]
+    assert defaults[keys["founded_year"]] == (2018, 2024)
+    assert defaults[keys["name_query"]] == ""
 
 
 def test_companies_to_table_rows_renders_sector_labels() -> None:


### PR DESCRIPTION
Closes #50

## Summary
- added explicit Reset controls to Map and Companies filters
- grouped Admin under Operations in the sidebar
- moved Digest spend metrics into a lower collapsed expander
- added tests for navigation grouping and filter reset defaults

## Verification
- `.venv/bin/pytest -q`
- `.venv/bin/ruff check .`
- `.venv/bin/black --check .`
- local browser smoke on `http://127.0.0.1:8510` for Map, Companies, and Digest