### PR TITLE
[codex] Fix dashboard sidebar same-tab navigation

### DIFF
--- a/dashboard/components/theme.py
+++ b/dashboard/components/theme.py
@@ -10,7 +10,7 @@ See ``docs/design-system.md`` for the design tokens themselves.
 from __future__ import annotations
 
 import json
-from html import escape
+from dataclasses import dataclass
 from pathlib import Path
 
 import streamlit as st
@@ -26,15 +26,25 @@ _DESCRIPTION: str = (
     "Live ecosystem map of the Australian and New Zealand AI startup landscape, "
     "updated weekly by an automated agent pipeline."
 )
-_PUBLIC_NAV_ITEMS: tuple[tuple[str, str], ...] = (
-    ("/", "Overview"),
-    ("/About", "About"),
-    ("/Map", "Map"),
-    ("/Companies", "Companies"),
-    ("/News", "News"),
-    ("/Digest", "Digest"),
+
+
+@dataclass(frozen=True)
+class NavItem:
+    """A dashboard page exposed in the sidebar navigation."""
+
+    page: str
+    label: str
+
+
+_PUBLIC_NAV_ITEMS: tuple[NavItem, ...] = (
+    NavItem("streamlit_app.py", "Overview"),
+    NavItem("pages/0_About.py", "About"),
+    NavItem("pages/1_Map.py", "Map"),
+    NavItem("pages/2_Companies.py", "Companies"),
+    NavItem("pages/3_News.py", "News"),
+    NavItem("pages/4_Digest.py", "Digest"),
 )
-_OPERATIONS_NAV_ITEMS: tuple[tuple[str, str], ...] = (("/Admin", "Admin"),)
+_OPERATIONS_NAV_ITEMS: tuple[NavItem, ...] = (NavItem("pages/90_Admin.py", "Admin"),)
 
 
 def _inject_styles() -> None:
@@ -112,43 +122,42 @@ def _active_nav_label(title: str) -> str:
     return "Overview"
 
 
-def _sidebar_nav_html(*, active_label: str) -> str:
-    """Render the project navigation as stable HTML instead of Streamlit's native nav."""
-    public_items: list[str] = []
-    operations_items: list[str] = []
-    for href, label in _PUBLIC_NAV_ITEMS:
-        active_attr = ' aria-current="page"' if label == active_label else ""
-        class_name = "aisw-sidebar-nav__link"
-        if label == active_label:
-            class_name += " aisw-sidebar-nav__link--active"
-        public_items.append(
-            f'<a class="{class_name}" href="{escape(href)}"{active_attr}>' f"{escape(label)}</a>"
-        )
-    for href, label in _OPERATIONS_NAV_ITEMS:
-        active_attr = ' aria-current="page"' if label == active_label else ""
-        class_name = "aisw-sidebar-nav__link aisw-sidebar-nav__link--operations"
-        if label == active_label:
-            class_name += " aisw-sidebar-nav__link--active"
-        operations_items.append(
-            f'<a class="{class_name}" href="{escape(href)}"{active_attr}>' f"{escape(label)}</a>"
-        )
-    return (
-        '<nav class="aisw-sidebar-nav" aria-label="Dashboard navigation">'
-        '<div class="aisw-sidebar-nav__eyebrow">Dashboard</div>'
-        + "".join(public_items)
-        + '<div class="aisw-sidebar-nav__section">Operations</div>'
-        + "".join(operations_items)
-        + "</nav>"
+def _nav_items_with_active(*, active_label: str) -> tuple[tuple[str, str, bool], ...]:
+    """Return sidebar page links with their active state."""
+    return tuple(
+        (item.page, item.label, item.label == active_label)
+        for item in (*_PUBLIC_NAV_ITEMS, *_OPERATIONS_NAV_ITEMS)
     )
 
 
 def _render_sidebar_nav(*, title: str) -> None:
     """Render the dashboard navigation in the intended order."""
+    active_label = _active_nav_label(title)
     with st.sidebar:
         st.markdown(
-            _sidebar_nav_html(active_label=_active_nav_label(title)),
+            '<div class="aisw-sidebar-nav" aria-label="Dashboard navigation">'
+            '<div class="aisw-sidebar-nav__eyebrow">Dashboard</div>'
+            "</div>",
             unsafe_allow_html=True,
         )
+        for item in _PUBLIC_NAV_ITEMS:
+            st.page_link(
+                item.page,
+                label=item.label,
+                disabled=item.label == active_label,
+                use_container_width=True,
+            )
+        st.markdown(
+            '<div class="aisw-sidebar-nav__section">Operations</div>',
+            unsafe_allow_html=True,
+        )
+        for item in _OPERATIONS_NAV_ITEMS:
+            st.page_link(
+                item.page,
+                label=item.label,
+                disabled=item.label == active_label,
+                use_container_width=True,
+            )
 
 
 def render_page_chrome(*, title: str, page_icon: str = "🌏") -> None:

--- a/dashboard/static/styles.css
+++ b/dashboard/static/styles.css
@@ -107,10 +107,8 @@ code, pre, kbd, samp {
 .aisw-sidebar-nav {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  margin: 0 0 1.5rem 0;
-  padding: 0 0 1.25rem 0;
-  border-bottom: 1px solid var(--aisw-border);
+  margin: 0 0 0.5rem 0;
+  padding: 0;
 }
 
 .aisw-sidebar-nav__eyebrow {
@@ -133,9 +131,15 @@ code, pre, kbd, samp {
   text-transform: uppercase;
 }
 
-.aisw-sidebar-nav__link,
-.aisw-sidebar-nav__link:visited {
-  display: block;
+[data-testid="stSidebar"] [data-testid="stPageLink"] {
+  margin: 0 0 0.25rem 0;
+}
+
+[data-testid="stSidebar"] [data-testid="stPageLink"] a,
+[data-testid="stSidebar"] [data-testid="stPageLink"] a:visited {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
   min-height: 2rem;
   padding: 0.4rem 0.65rem;
   border: 1px solid transparent;
@@ -149,21 +153,37 @@ code, pre, kbd, samp {
   text-decoration: none !important;
 }
 
-.aisw-sidebar-nav__link:hover {
+[data-testid="stSidebar"] [data-testid="stPageLink"] a p,
+[data-testid="stSidebar"] [data-testid="stPageLink"] a span {
+  color: inherit !important;
+  font-size: inherit !important;
+  font-weight: inherit !important;
+  line-height: inherit !important;
+}
+
+[data-testid="stSidebar"] [data-testid="stPageLink"] a:hover {
   background: rgba(244, 183, 64, 0.08);
   border-color: rgba(244, 183, 64, 0.28);
   color: var(--aisw-text) !important;
 }
 
-.aisw-sidebar-nav__link--active,
-.aisw-sidebar-nav__link--active:visited {
+[data-testid="stSidebar"] [data-testid="stPageLink"] a[aria-disabled="true"],
+[data-testid="stSidebar"] [data-testid="stPageLink"] a[disabled] {
   background: var(--aisw-accent-soft);
   border-color: rgba(244, 183, 64, 0.42);
   color: var(--aisw-accent-hover) !important;
+  opacity: 1;
+  pointer-events: none;
 }
 
-.aisw-sidebar-nav__link--operations {
-  color: var(--aisw-text-subtle) !important;
+[data-testid="stSidebar"] [data-testid="stPageLink"]:has(a[aria-disabled="true"]),
+[data-testid="stSidebar"] [data-testid="stPageLink"]:has(a[disabled]) {
+  cursor: default;
+}
+
+[data-testid="stSidebar"] [data-testid="stPageLink"]:last-of-type {
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--aisw-border);
 }
 
 /* Headings: editorial hierarchy, deliberate spacing */

--- a/tests/test_dashboard_theme.py
+++ b/tests/test_dashboard_theme.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from dashboard.components.theme import _active_nav_label, _sidebar_nav_html
+from dashboard.components import theme
+from dashboard.components.theme import _active_nav_label, _nav_items_with_active
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -16,21 +17,47 @@ def test_active_nav_label_maps_page_titles() -> None:
 
 
 def test_sidebar_nav_marks_one_current_page() -> None:
-    html = _sidebar_nav_html(active_label="Map")
+    items = _nav_items_with_active(active_label="Map")
 
-    assert html.count('aria-current="page"') == 1
-    assert 'href="/"' in html
-    assert 'href="/Map"' in html
-    assert "aisw-sidebar-nav__link--active" in html
+    assert sum(1 for _, _, is_active in items if is_active) == 1
+    assert ("streamlit_app.py", "Overview", False) in items
+    assert ("pages/1_Map.py", "Map", True) in items
+
+
+def test_sidebar_nav_uses_streamlit_page_links(monkeypatch) -> None:
+    calls: list[tuple[str, str, bool, bool]] = []
+    markdown_calls: list[str] = []
+
+    class Sidebar:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, exc_type, exc_value, traceback) -> None:
+            return None
+
+    def page_link(page: str, *, label: str, disabled: bool, use_container_width: bool) -> None:
+        calls.append((page, label, disabled, use_container_width))
+
+    monkeypatch.setattr(theme.st, "sidebar", Sidebar())
+    monkeypatch.setattr(
+        theme.st, "markdown", lambda body, *args, **kwargs: markdown_calls.append(body)
+    )
+    monkeypatch.setattr(theme.st, "page_link", page_link)
+
+    theme._render_sidebar_nav(title="AI Sector Watch: Map")
+
+    assert calls[0] == ("streamlit_app.py", "Overview", False, True)
+    assert ("pages/1_Map.py", "Map", True, True) in calls
+    assert ("pages/90_Admin.py", "Admin", False, True) in calls
+    assert any("Operations" in body for body in markdown_calls)
+    assert all(not page.startswith("/") for page, _, _, _ in calls)
 
 
 def test_sidebar_nav_separates_admin_from_public_pages() -> None:
-    html = _sidebar_nav_html(active_label="Admin")
+    items = _nav_items_with_active(active_label="Admin")
 
-    assert "Operations" in html
-    assert 'href="/Admin"' in html
-    assert "aisw-sidebar-nav__link--operations" in html
-    assert html.count('aria-current="page"') == 1
+    assert ("pages/90_Admin.py", "Admin", True) in items
+    assert sum(1 for _, _, is_active in items if is_active) == 1
 
 
 def test_docker_image_includes_streamlit_config() -> None:


### PR DESCRIPTION
## Summary

- Replace raw sidebar navigation anchors with Streamlit `st.page_link` entries using internal page file paths.
- Preserve the Dashboard and Operations sidebar grouping while keeping the active page disabled.
- Update dashboard theme tests to assert internal page paths are used instead of URL-style anchors.

## Root Cause

The custom sidebar rendered raw HTML anchors with URL paths such as `/Map`. Streamlit treated those like normal links, so clicking a sidebar page could open a new browser tab instead of switching the current Streamlit page.

## Validation

- `ruff check .`
- `black --check .`
- `pytest -q`
- Local Streamlit smoke test: clicking `Map` kept browser page count at 1 and navigated to `/Map` in the same tab.