### PR TITLE
[codex] Address automated review feedback

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -81,7 +81,7 @@ Commit:
 ## Step 6 — push and open a Draft PR
 
     cd <WT> && git push -u origin HEAD
-    cd <WT> && gh pr create --draft --title "[#<#>] <issue title>" --body "Closes #<#>"
+    cd <WT> && PR_BODY="$(mktemp)" && cp .github/pull_request_template.md "$PR_BODY" && printf "\nCloses #%s\n" "<#>" >> "$PR_BODY" && gh pr create --draft --title "[#<#>] <issue title>" --body-file "$PR_BODY"
 
 Use the issue title verbatim from `gh issue view <#> --json title -q .title`.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,7 +89,13 @@
     ],
     "deny": [
       "Bash(git push --force)",
+      "Bash(git push --force:*)",
+      "Bash(git push:* --force)",
+      "Bash(git push:* --force:*)",
       "Bash(git push -f)",
+      "Bash(git push -f:*)",
+      "Bash(git push:* -f)",
+      "Bash(git push:* -f:*)",
       "Bash(git push:* main)",
       "Bash(git push origin main:*)",
       "Bash(git reset --hard:*)",

--- a/.codex/prompts/issue.md
+++ b/.codex/prompts/issue.md
@@ -81,7 +81,7 @@ Commit:
 ## Step 6 — push and open a Draft PR
 
     cd <WT> && git push -u origin HEAD
-    cd <WT> && gh pr create --draft --title "[#<#>] <issue title>" --body "Closes #<#>"
+    cd <WT> && PR_BODY="$(mktemp)" && cp .github/pull_request_template.md "$PR_BODY" && printf "\nCloses #%s\n" "<#>" >> "$PR_BODY" && gh pr create --draft --title "[#<#>] <issue title>" --body-file "$PR_BODY"
 
 Use the issue title verbatim from `gh issue view <#> --json title -q .title`.
 

--- a/scripts/audit_company_profiles.py
+++ b/scripts/audit_company_profiles.py
@@ -101,6 +101,10 @@ class AuditArtifacts:
     json_path: Path
 
 
+class AuditBudgetExceeded(RuntimeError):
+    """Raised when the audit cannot finish within the configured budgets."""
+
+
 def _is_empty(value: Any) -> bool:
     if value is None:
         return True
@@ -407,8 +411,9 @@ def run_audit(
                 name=name,
             )
         except (BudgetExceeded, FirecrawlBudgetExceeded) as exc:
-            LOGGER.warning("budget exhausted while auditing %s: %s", name, exc)
-            break
+            raise AuditBudgetExceeded(
+                f"budget exhausted while auditing {name}; audit artifacts would be incomplete"
+            ) from exc
         updates = _fact_to_updates(company, facts)
         findings.extend(_findings_for_update(company, facts, updates))
         if updates:
@@ -471,15 +476,19 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     if args.enrich:
         LOGGER.info("estimated Firecrawl credits for this run: %d", estimated_credits)
-    artifacts = run_audit(
-        limit=args.limit,
-        offset=args.offset,
-        dry_run=args.dry_run,
-        enrich=args.enrich,
-        output_dir=args.output_dir,
-        run_date=args.run_date,
-        artifact_suffix=args.artifact_suffix,
-    )
+    try:
+        artifacts = run_audit(
+            limit=args.limit,
+            offset=args.offset,
+            dry_run=args.dry_run,
+            enrich=args.enrich,
+            output_dir=args.output_dir,
+            run_date=args.run_date,
+            artifact_suffix=args.artifact_suffix,
+        )
+    except AuditBudgetExceeded as exc:
+        LOGGER.error("%s", exc)
+        return 1
     print(json.dumps({k: str(v) for k, v in asdict(artifacts).items()}, indent=2))
     return 0
 

--- a/src/ai_sector_watch/storage/supabase_db.py
+++ b/src/ai_sector_watch/storage/supabase_db.py
@@ -339,6 +339,17 @@ def companies_has_enriched_at(conn: psycopg.Connection) -> bool:
     return companies_has_column(conn, "enriched_at")
 
 
+def _company_column_select(
+    conn: psycopg.Connection,
+    column_name: str,
+    fallback: sql.SQL,
+) -> sql.Composable:
+    """Return a real company column or a typed fallback alias."""
+    if companies_has_column(conn, column_name):
+        return sql.Identifier(column_name)
+    return fallback
+
+
 def list_companies_for_enrichment(
     conn: psycopg.Connection,
     *,
@@ -356,6 +367,29 @@ def list_companies_for_enrichment(
         if companies_has_enriched_at(conn)
         else sql.SQL("NULL::TIMESTAMPTZ AS enriched_at")
     )
+    optional_profile_selects = {
+        "founders": sql.SQL("'{}'::TEXT[] AS founders"),
+        "total_raised_usd": sql.SQL("NULL::NUMERIC AS total_raised_usd"),
+        "total_raised_currency_raw": sql.SQL("NULL::TEXT AS total_raised_currency_raw"),
+        "total_raised_as_of": sql.SQL("NULL::DATE AS total_raised_as_of"),
+        "total_raised_source_url": sql.SQL("NULL::TEXT AS total_raised_source_url"),
+        "valuation_usd": sql.SQL("NULL::NUMERIC AS valuation_usd"),
+        "valuation_currency_raw": sql.SQL("NULL::TEXT AS valuation_currency_raw"),
+        "valuation_as_of": sql.SQL("NULL::DATE AS valuation_as_of"),
+        "valuation_source_url": sql.SQL("NULL::TEXT AS valuation_source_url"),
+        "headcount_estimate": sql.SQL("NULL::INTEGER AS headcount_estimate"),
+        "headcount_min": sql.SQL("NULL::INTEGER AS headcount_min"),
+        "headcount_max": sql.SQL("NULL::INTEGER AS headcount_max"),
+        "headcount_as_of": sql.SQL("NULL::DATE AS headcount_as_of"),
+        "headcount_source_url": sql.SQL("NULL::TEXT AS headcount_source_url"),
+        "profile_confidence": sql.SQL("NULL::NUMERIC AS profile_confidence"),
+        "profile_sources": sql.SQL("'{}'::TEXT[] AS profile_sources"),
+        "profile_verified_at": sql.SQL("NULL::TIMESTAMPTZ AS profile_verified_at"),
+    }
+    profile_selects = [
+        _company_column_select(conn, column_name, fallback)
+        for column_name, fallback in optional_profile_selects.items()
+    ]
     limit_clause = sql.SQL("LIMIT %s") if limit is not None else sql.SQL("")
     params: list[Any] = [max_age_years]
     if limit is not None:
@@ -364,12 +398,7 @@ def list_companies_for_enrichment(
         SELECT
             id, name, website, country, city, lat, lon, sector_tags, stage,
             founded_year, summary, {evidence_urls_select}, {enriched_at_select},
-            founders, total_raised_usd, total_raised_currency_raw,
-            total_raised_as_of, total_raised_source_url, valuation_usd,
-            valuation_currency_raw, valuation_as_of, valuation_source_url,
-            headcount_estimate, headcount_min, headcount_max, headcount_as_of,
-            headcount_source_url, profile_confidence, profile_sources,
-            profile_verified_at
+            {profile_selects}
         FROM companies
         WHERE discovery_status = 'verified'
           AND (
@@ -381,6 +410,7 @@ def list_companies_for_enrichment(
         """).format(
         evidence_urls_select=evidence_urls_select,
         enriched_at_select=enriched_at_select,
+        profile_selects=sql.SQL(", ").join(profile_selects),
         limit_clause=limit_clause,
     )
     with conn.cursor() as cur:

--- a/tests/test_audit_company_profiles.py
+++ b/tests/test_audit_company_profiles.py
@@ -1,0 +1,92 @@
+"""Tests for the company profile audit script."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import audit_company_profiles as audit_profiles  # noqa: E402
+
+from ai_sector_watch.extraction.claude_client import BudgetExceeded  # noqa: E402
+
+
+class FakeFirecrawlClient:
+    """FirecrawlClient stand-in with only the fields the audit reads."""
+
+    def __init__(self) -> None:
+        self.stats = SimpleNamespace(credits_used=0)
+
+
+class FakeClaudeClient:
+    """ClaudeClient stand-in with only the fields the audit reads."""
+
+    def __init__(self) -> None:
+        self.stats = SimpleNamespace(calls=0)
+
+
+def test_enriched_audit_fails_when_budget_exhaustion_truncates_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Budget exhaustion should not produce successful partial audit artifacts."""
+    monkeypatch.setattr(
+        audit_profiles,
+        "_load_companies",
+        lambda *, statuses, limit, offset: [
+            {
+                "id": "company-1",
+                "name": "Budget Target",
+                "website": "https://budget.example",
+                "discovery_status": "verified",
+                "sector_tags": [],
+            }
+        ],
+    )
+    monkeypatch.setattr(audit_profiles, "FirecrawlClient", FakeFirecrawlClient)
+    monkeypatch.setattr(audit_profiles, "ClaudeClient", FakeClaudeClient)
+
+    def fake_enrich(client, llm_client, website: str, *, name: str):
+        raise BudgetExceeded("test budget exhausted")
+
+    monkeypatch.setattr(audit_profiles, "firecrawl_enrich", fake_enrich)
+
+    with pytest.raises(audit_profiles.AuditBudgetExceeded):
+        audit_profiles.run_audit(
+            limit=1,
+            offset=0,
+            dry_run=False,
+            enrich=True,
+            output_dir=tmp_path,
+            run_date=audit_profiles.date(2026, 4, 28),
+            artifact_suffix=None,
+        )
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_main_returns_nonzero_when_budget_exhaustion_truncates_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The CLI should fail cleanly when an enriched audit is incomplete."""
+    monkeypatch.setattr(
+        audit_profiles,
+        "run_audit",
+        lambda **kwargs: (_ for _ in ()).throw(audit_profiles.AuditBudgetExceeded("truncated")),
+    )
+
+    status = audit_profiles.main(
+        [
+            "--enrich",
+            "--limit",
+            "1",
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert status == 1

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -61,6 +61,60 @@ def test_get_conn_raises_when_supabase_db_url_unset(monkeypatch) -> None:
         supabase_db._get_db_url()
 
 
+def test_list_companies_for_enrichment_checks_optional_profile_columns(monkeypatch) -> None:
+    checked_columns: list[str] = []
+
+    class FakeCursor:
+        def __enter__(self) -> FakeCursor:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def execute(self, query, params) -> None:
+            self.query = query
+            self.params = params
+
+        def fetchall(self) -> list[dict[str, object]]:
+            return []
+
+    class FakeConn:
+        def cursor(self) -> FakeCursor:
+            return FakeCursor()
+
+    def fake_has_column(conn, column_name: str) -> bool:
+        checked_columns.append(column_name)
+        return False
+
+    monkeypatch.setattr(supabase_db, "companies_has_column", fake_has_column)
+
+    rows = supabase_db.list_companies_for_enrichment(FakeConn(), max_age_years=5, limit=10)
+
+    assert rows == []
+    for column_name in (
+        "evidence_urls",
+        "enriched_at",
+        "founders",
+        "total_raised_usd",
+        "total_raised_currency_raw",
+        "total_raised_as_of",
+        "total_raised_source_url",
+        "valuation_usd",
+        "valuation_currency_raw",
+        "valuation_as_of",
+        "valuation_source_url",
+        "headcount_estimate",
+        "headcount_min",
+        "headcount_max",
+        "headcount_as_of",
+        "headcount_source_url",
+        "profile_confidence",
+        "profile_sources",
+        "profile_verified_at",
+    ):
+        assert column_name in checked_columns
+
+
 # ----- Live integration tests (skipped without SUPABASE_DB_URL) --------------
 
 pytestmark_live = pytest.mark.skipif(


### PR DESCRIPTION
## Summary

Addresses the unresolved automated review findings left on today's merged PRs.

## Why

The review comments identified guardrail gaps in the issue workflow and two audit/enrichment edge cases that should be fixed before relying on those operator paths.

## Changes

- Harden Claude force-push deny patterns for argument-bearing variants.
- Preserve the PR template when the issue prompt opens draft PRs.
- Guard new enrichment profile columns when querying legacy Supabase schemas.
- Fail enriched company profile audits when budget exhaustion would truncate artifacts.
- Add focused regression tests for the storage and audit fixes.

## Test plan

- [x] `.venv/bin/pytest -q` passes
- [x] `.venv/bin/ruff check .` passes
- [x] `.venv/bin/black --check .` passes
- [x] Manual smoke check: reviewed today's PR review threads and confirmed these changes cover the unresolved P2 findings
- [x] `PROJECT_PROGRESS.md` not updated, not a milestone

## Multi-agent coordination

- [x] Work was done in a dedicated worktree: `/Users/samuelclifton/Documents/Projects/AI-Sector-Watch-codex-review-audit`
- [ ] Linked issue assignee: not applicable, no issue for this cleanup
- [ ] Issue-number branch naming: not applicable, no issue for this cleanup
- [x] Branch is based on latest `origin/main` at worktree creation

## Screenshots

Not applicable.

## Related issues

None.