### PR TITLE
[#58] PR1: same-tab nav, cache Supabase reads, switch to Voyager tiles

### DIFF
--- a/dashboard/components/data_loaders.py
+++ b/dashboard/components/data_loaders.py
@@ -1,0 +1,41 @@
+"""Cached read accessors for the dashboard.
+
+`@st.cache_resource` keeps a single ``DataSource`` per Streamlit process so
+the Supabase connection pool is reused across reruns. ``@st.cache_data``
+memoises read results so navigating between pages and tweaking filters does
+not re-run identical SQL within the TTL window.
+
+Mutation paths (admin Promote / Reject) must call ``load_companies.clear()``
+after writing so the public dashboard reflects the change on next render.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from ai_sector_watch.storage.data_source import (
+    Company,
+    DataSource,
+    NewsItem,
+    get_data_source,
+)
+
+_DEFAULT_TTL_SECONDS = 600
+
+
+@st.cache_resource(show_spinner=False)
+def get_source() -> DataSource:
+    """Return the process-singleton data source backend."""
+    return get_data_source()
+
+
+@st.cache_data(ttl=_DEFAULT_TTL_SECONDS, show_spinner=False)
+def load_companies(statuses: tuple[str, ...] = ("verified",)) -> list[Company]:
+    """Return companies for the given statuses, cached for ``_DEFAULT_TTL_SECONDS``."""
+    return get_source().list_companies(statuses=statuses)
+
+
+@st.cache_data(ttl=_DEFAULT_TTL_SECONDS, show_spinner=False)
+def load_news(limit: int = 100) -> list[NewsItem]:
+    """Return the most recent news items, cached for ``_DEFAULT_TTL_SECONDS``."""
+    return get_source().recent_news(limit=limit)

--- a/dashboard/components/map_view.py
+++ b/dashboard/components/map_view.py
@@ -91,7 +91,7 @@ def build_map(companies: list[Company]) -> folium.Map:
     fmap = folium.Map(
         location=_DEFAULT_CENTER,
         zoom_start=_DEFAULT_ZOOM,
-        tiles="cartodbpositron",
+        tiles="CartoDB Voyager",
         control_scale=True,
     )
     fmap.get_root().header.add_child(folium.Element(f"<style>{_POPUP_CSS}</style>"))

--- a/dashboard/pages/1_Map.py
+++ b/dashboard/pages/1_Map.py
@@ -13,7 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from ai_sector_watch.storage.data_source import get_data_source  # noqa: E402
+from dashboard.components.data_loaders import get_source, load_companies  # noqa: E402
 from dashboard.components.filters import (  # noqa: E402
     apply_filters,
     companies_to_table_rows,
@@ -32,8 +32,8 @@ def main() -> None:
     st.title("Map")
     st.caption("Click a marker for company detail. Markers cluster at low zoom.")
 
-    source = get_data_source()
-    all_companies = source.list_companies()
+    source = get_source()
+    all_companies = load_companies()
 
     if source.backend == "yaml":
         st.info(

--- a/dashboard/pages/2_Companies.py
+++ b/dashboard/pages/2_Companies.py
@@ -13,7 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from ai_sector_watch.storage.data_source import get_data_source  # noqa: E402
+from dashboard.components.data_loaders import get_source, load_companies  # noqa: E402
 from dashboard.components.filters import (  # noqa: E402
     apply_filters,
     companies_to_table_rows,
@@ -30,8 +30,8 @@ def main() -> None:
     st.title("Companies")
     st.caption("Every verified company in the index, filterable from the sidebar.")
 
-    source = get_data_source()
-    all_companies = source.list_companies()
+    source = get_source()
+    all_companies = load_companies()
 
     if source.backend == "yaml":
         st.info(

--- a/dashboard/pages/3_News.py
+++ b/dashboard/pages/3_News.py
@@ -11,7 +11,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from ai_sector_watch.storage.data_source import get_data_source  # noqa: E402
+from dashboard.components.data_loaders import (  # noqa: E402
+    get_source,
+    load_companies,
+    load_news,
+)
 from dashboard.components.footer import render_footer  # noqa: E402
 from dashboard.components.theme import render_page_chrome  # noqa: E402
 
@@ -25,9 +29,9 @@ def main() -> None:
         "partnerships from the past week's pipeline run."
     )
 
-    source = get_data_source()
-    news = source.recent_news(limit=100)
-    companies = {c.id: c for c in source.list_companies()}
+    source = get_source()
+    news = load_news(limit=100)
+    companies = {c.id: c for c in load_companies()}
 
     if source.backend == "yaml" or not news:
         st.info(

--- a/dashboard/pages/90_Admin.py
+++ b/dashboard/pages/90_Admin.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from ai_sector_watch.config import get_config  # noqa: E402
 from ai_sector_watch.storage import supabase_db  # noqa: E402
+from dashboard.components.data_loaders import load_companies  # noqa: E402
 from dashboard.components.footer import render_footer  # noqa: E402
 from dashboard.components.theme import render_page_chrome  # noqa: E402
 
@@ -118,12 +119,14 @@ def main() -> None:
             with supabase_db.connection() as conn:
                 supabase_db.set_company_status(conn, str(chosen["id"]), "verified")
                 conn.commit()
+            load_companies.clear()
             st.success(f"{chosen['name']} is now verified and will appear on the map.")
             st.rerun()
         if col2.button("Reject"):
             with supabase_db.connection() as conn:
                 supabase_db.set_company_status(conn, str(chosen["id"]), "rejected")
                 conn.commit()
+            load_companies.clear()
             st.success(f"{chosen['name']} marked as rejected.")
             st.rerun()
 

--- a/dashboard/streamlit_app.py
+++ b/dashboard/streamlit_app.py
@@ -15,7 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from ai_sector_watch.storage.data_source import get_data_source  # noqa: E402
+from dashboard.components.data_loaders import get_source, load_companies  # noqa: E402
 from dashboard.components.footer import render_footer  # noqa: E402
 from dashboard.components.theme import render_page_chrome  # noqa: E402
 
@@ -23,8 +23,8 @@ render_page_chrome(title="AI Sector Watch", page_icon="🌏")
 
 
 def main() -> None:
-    source = get_data_source()
-    companies = source.list_companies()
+    source = get_source()
+    companies = load_companies()
 
     st.title("AI Sector Watch")
     st.write(
@@ -54,9 +54,25 @@ def main() -> None:
         "wait in the admin review queue before they appear on the map or company list."
     )
     action_cols = st.columns([1, 1, 1, 2])
-    action_cols[0].link_button("Map", "/Map", type="primary")
-    action_cols[1].link_button("Companies", "/Companies")
-    action_cols[2].link_button("News", "/News")
+    if action_cols[0].button(
+        "Open the map",
+        type="primary",
+        use_container_width=True,
+        icon=":material/map:",
+    ):
+        st.switch_page("pages/1_Map.py")
+    if action_cols[1].button(
+        "Browse companies",
+        use_container_width=True,
+        icon=":material/business:",
+    ):
+        st.switch_page("pages/2_Companies.py")
+    if action_cols[2].button(
+        "Read the news feed",
+        use_container_width=True,
+        icon=":material/article:",
+    ):
+        st.switch_page("pages/3_News.py")
 
     render_footer()
 


### PR DESCRIPTION
First of two PRs against #58. Small, low-risk bundle of the three confirmed bugs.

## Summary

- **Same-tab nav.** `dashboard/streamlit_app.py` was using `st.link_button("Map", "/Map")`, which is the external-URL primitive and always opens a new tab. Swapped for `st.button(..., on click) + st.switch_page(...)` so the homepage primary actions navigate in-app, matching the sidebar behaviour.
- **Caching.** Added `dashboard/components/data_loaders.py` with `@st.cache_resource` for the data source factory and `@st.cache_data(ttl=600)` for `load_companies` / `load_news`. Swapped call sites on Home, Map, Companies, News. Admin Promote / Reject now call `load_companies.clear()` after writes so the public dashboard refreshes on next render.
- **Voyager tiles.** `dashboard/components/map_view.py` swaps Positron for CartoDB Voyager: same low-contrast palette, but parks / water / transit add a bit of useful hierarchy.

PR2 (visual polish: DivIcon markers, cluster icons, shadcn metric cards, popovers, fragments, font config) will follow on a sibling branch off this one.

## Test plan

- [x] `pytest -q` (74 pass, 2 live-DB tests skipped as expected)
- [x] `ruff check .` (clean)
- [x] `black --check .` (clean)
- [x] Smoke: `folium.Map(tiles="CartoDB Voyager")` renders with Voyager tiles
- [x] Smoke: cached loaders import cleanly and produce `<CachedFunc>` wrappers
- [ ] Manual: click each homepage primary action, confirm URL changes in same tab
- [ ] Manual: navigate Home -> Map -> Companies -> Home with `print` in source method, confirm one fetch per type within TTL
- [ ] Manual: Voyager base layer visible on `/Map`

Closes part of #58.