### PR TITLE
[#58] PR2: visual polish — branded markers, KPIs, help popovers, fragments

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -6,7 +6,8 @@ primaryColor = "#F4B740"
 backgroundColor = "#0B0F14"
 secondaryBackgroundColor = "#121821"
 textColor = "#E6EDF3"
-font = "sans-serif"
+font = "Inter:https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+codeFont = "JetBrains Mono:https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap"
 
 [browser]
 gatherUsageStats = false

--- a/dashboard/components/filters.py
+++ b/dashboard/components/filters.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date
-from decimal import Decimal
 
 import streamlit as st
 
@@ -194,8 +193,23 @@ def apply_filters(companies: list[Company], state: FilterState) -> list[Company]
     return out
 
 
+_STAGE_LABELS: dict[str, str] = {
+    "pre_seed": "Pre-seed",
+    "seed": "Seed",
+    "series_a": "Series A",
+    "series_b_plus": "Series B+",
+    "mature": "Mature",
+}
+
+
 def companies_to_table_rows(companies: list[Company]) -> list[dict]:
-    """Convert Company list -> list of dicts ready for st.dataframe."""
+    """Convert Company list -> list of dicts ready for st.dataframe.
+
+    Profile-enrichment fields (founders, total raised, valuation, headcount)
+    are intentionally excluded: coverage is sparse and a column full of blanks
+    reads as broken. Those values surface on the per-company detail card on
+    the Companies page instead.
+    """
     rows = []
     for c in companies:
         rows.append(
@@ -203,49 +217,12 @@ def companies_to_table_rows(companies: list[Company]) -> list[dict]:
                 "Name": c.name,
                 "Country": c.country or "",
                 "City": c.city or "",
-                "Stage": c.stage or "",
+                "Stage": _STAGE_LABELS.get(c.stage or "", c.stage or ""),
                 "Founded": c.founded_year,
-                "Raised": _format_usd(c.total_raised_usd),
-                "Valuation": _format_usd(c.valuation_usd),
-                "Headcount": _format_headcount(c),
-                "Founders": ", ".join(c.founders),
                 "Sectors": ", ".join(
                     (get_sector(t).label if get_sector(t) else t) for t in c.sector_tags
                 ),
-                "Verified": c.profile_verified_at.date() if c.profile_verified_at else None,
                 "Website": c.website or "",
             }
         )
     return rows
-
-
-def _format_usd(amount: Decimal | None) -> str:
-    """Return a compact USD amount for table cells."""
-    if amount is None:
-        return ""
-    if amount >= Decimal("1000000000"):
-        billions = amount / Decimal("1000000000")
-        value = f"{billions:.1f}".rstrip("0").rstrip(".")
-        return f"US${value}B"
-    if amount >= Decimal("1000000"):
-        millions = amount / Decimal("1000000")
-        value = f"{millions:.1f}".rstrip("0").rstrip(".")
-        return f"US${value}M"
-    if amount >= Decimal("1000"):
-        thousands = amount / Decimal("1000")
-        value = f"{thousands:.1f}".rstrip("0").rstrip(".")
-        return f"US${value}K"
-    return f"US${amount:,.0f}"
-
-
-def _format_headcount(company: Company) -> str:
-    """Return the best available headcount display string."""
-    if company.headcount_estimate is not None:
-        return str(company.headcount_estimate)
-    if company.headcount_min is not None and company.headcount_max is not None:
-        return f"{company.headcount_min}-{company.headcount_max}"
-    if company.headcount_min is not None:
-        return f"{company.headcount_min}+"
-    if company.headcount_max is not None:
-        return f"up to {company.headcount_max}"
-    return ""

--- a/dashboard/components/filters.py
+++ b/dashboard/components/filters.py
@@ -149,12 +149,14 @@ def render_sidebar(
             min_value=founded_min,
             max_value=founded_max,
             step=1,
+            help="Companies whose founded year falls outside this range are hidden.",
             key=keys["founded_year"],
         )
 
         name_query = st.text_input(
             "Search name",
             placeholder="e.g. Marqo",
+            help="Case-insensitive substring match against the company name.",
             key=keys["name_query"],
         )
 

--- a/dashboard/components/map_view.py
+++ b/dashboard/components/map_view.py
@@ -10,7 +10,7 @@ from folium.plugins import MarkerCluster
 
 from ai_sector_watch.discovery.taxonomy import (
     get_sector,
-    primary_sector_colour,
+    primary_sector_hex,
 )
 from ai_sector_watch.storage.data_source import Company
 
@@ -83,6 +83,55 @@ _POPUP_CSS: str = """
   line-height: 1.45;
   color: var(--aisw-text);
 }
+.aisw-marker-wrap {
+  background: transparent !important;
+  border: 0 !important;
+}
+.aisw-marker {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid #0B0F14;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.18), 0 1px 4px rgba(0, 0, 0, 0.45);
+  transition: transform 120ms ease;
+}
+.aisw-marker:hover {
+  transform: scale(1.25);
+}
+.aisw-cluster-wrap {
+  background: transparent !important;
+  border: 0 !important;
+}
+.aisw-cluster {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #F4B740;
+  color: #0B0F14;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  border: 2px solid rgba(11, 15, 20, 0.85);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
+  transition: background 120ms ease;
+}
+.aisw-cluster:hover {
+  background: #FFD074;
+}
+"""
+
+_CLUSTER_ICON_JS: str = """
+function (cluster) {
+  var count = cluster.getChildCount();
+  return L.divIcon({
+    html: '<div class="aisw-cluster"><span>' + count + '</span></div>',
+    className: 'aisw-cluster-wrap',
+    iconSize: L.point(36, 36)
+  });
+}
 """
 
 
@@ -95,17 +144,24 @@ def build_map(companies: list[Company]) -> folium.Map:
         control_scale=True,
     )
     fmap.get_root().header.add_child(folium.Element(f"<style>{_POPUP_CSS}</style>"))
-    cluster = MarkerCluster(name="Companies", show=True).add_to(fmap)
+    cluster = MarkerCluster(
+        name="Companies",
+        show=True,
+        icon_create_function=_CLUSTER_ICON_JS,
+    ).add_to(fmap)
 
-    geocoded = 0
     for company in companies:
         if company.lat is None or company.lon is None:
             continue
-        geocoded += 1
-        colour = primary_sector_colour(company.sector_tags)
+        marker_hex = primary_sector_hex(company.sector_tags)
         folium.Marker(
             location=(company.lat, company.lon),
-            icon=folium.Icon(color=colour, icon="info-sign"),
+            icon=folium.DivIcon(
+                html=f'<div class="aisw-marker" style="background:{marker_hex};"></div>',
+                icon_size=(14, 14),
+                icon_anchor=(7, 7),
+                class_name="aisw-marker-wrap",
+            ),
             popup=folium.Popup(_popup_html(company), max_width=320),
             tooltip=company.name,
         ).add_to(cluster)

--- a/dashboard/components/sector_legend.py
+++ b/dashboard/components/sector_legend.py
@@ -7,7 +7,7 @@ from html import escape
 
 import streamlit as st
 
-from ai_sector_watch.discovery.taxonomy import _GROUP_COLOURS, SECTOR_GROUPS, SECTORS
+from ai_sector_watch.discovery.taxonomy import SECTOR_GROUPS, SECTORS, hex_for_group
 
 
 @dataclass(frozen=True)
@@ -29,7 +29,7 @@ def sector_legend_rows(*, max_examples: int = 3) -> tuple[SectorLegendRow, ...]:
             SectorLegendRow(
                 group=group,
                 label=_group_label(group),
-                colour=_GROUP_COLOURS[group],
+                colour=hex_for_group(group),
                 examples=examples,
             )
         )

--- a/dashboard/pages/1_Map.py
+++ b/dashboard/pages/1_Map.py
@@ -13,7 +13,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from ai_sector_watch.storage.data_source import Company  # noqa: E402
 from dashboard.components.data_loaders import get_source, load_companies  # noqa: E402
 from dashboard.components.filters import (  # noqa: E402
     apply_filters,
@@ -29,14 +28,32 @@ from dashboard.components.theme import render_page_chrome  # noqa: E402
 render_page_chrome(title="AI Sector Watch: Map", page_icon="🌏")
 
 
-@st.fragment
-def _filtered_map_view(all_companies: list[Company]) -> None:
-    """Render the filter sidebar, the map, and the in-view table.
+def main() -> None:
+    title_cols = st.columns([5, 1])
+    with title_cols[0]:
+        st.title("Map")
+        st.caption("Click a marker for company detail. Markers cluster at low zoom.")
+    with title_cols[1], st.popover("How to read this map", use_container_width=True):
+        st.markdown(
+            "**Each marker is one verified ANZ AI company.** Colour follows its "
+            "primary sector. The sidebar legend lists the colour groups.\n\n"
+            "**Gold bubbles** are clusters: the number is how many companies "
+            "sit at that zoom level. Click one to zoom in until the markers "
+            "split apart.\n\n"
+            "**Sidebar filters** narrow the map and the table below by sector, "
+            "stage, country, founded year, or name. The Reset button clears "
+            "every filter."
+        )
 
-    Wrapped in ``@st.fragment`` so changing a filter triggers a partial
-    rerun of just this block — the page title, popover, and brand
-    wordmark stay put instead of flashing.
-    """
+    source = get_source()
+    all_companies = load_companies()
+
+    if source.backend == "yaml":
+        st.info(
+            "Showing seed data from `data/seed/companies.yaml`. Set `SUPABASE_DB_URL` "
+            "to read from the live index."
+        )
+
     meta = derive_meta(all_companies)
     state = render_sidebar(meta, default_countries=("AU", "NZ"), key_prefix="map_filters")
     render_sector_legend()
@@ -71,35 +88,6 @@ def _filtered_map_view(all_companies: list[Company]) -> None:
         with st.expander(f"Companies without map coordinates ({len(off_map)})"):
             for c in off_map:
                 st.write(f"- **{c.name}** in {c.city or 'unknown city'}, {c.country or '?'}")
-
-
-def main() -> None:
-    title_cols = st.columns([5, 1])
-    with title_cols[0]:
-        st.title("Map")
-        st.caption("Click a marker for company detail. Markers cluster at low zoom.")
-    with title_cols[1], st.popover("How to read this map", use_container_width=True):
-        st.markdown(
-            "**Each marker is one verified ANZ AI company.** Colour follows its "
-            "primary sector. The sidebar legend lists the colour groups.\n\n"
-            "**Gold bubbles** are clusters: the number is how many companies "
-            "sit at that zoom level. Click one to zoom in until the markers "
-            "split apart.\n\n"
-            "**Sidebar filters** narrow the map and the table below by sector, "
-            "stage, country, founded year, or name. The Reset button clears "
-            "every filter."
-        )
-
-    source = get_source()
-    all_companies = load_companies()
-
-    if source.backend == "yaml":
-        st.info(
-            "Showing seed data from `data/seed/companies.yaml`. Set `SUPABASE_DB_URL` "
-            "to read from the live index."
-        )
-
-    _filtered_map_view(all_companies)
 
     render_footer()
 

--- a/dashboard/pages/1_Map.py
+++ b/dashboard/pages/1_Map.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
+from ai_sector_watch.storage.data_source import Company  # noqa: E402
 from dashboard.components.data_loaders import get_source, load_companies  # noqa: E402
 from dashboard.components.filters import (  # noqa: E402
     apply_filters,
@@ -28,32 +29,14 @@ from dashboard.components.theme import render_page_chrome  # noqa: E402
 render_page_chrome(title="AI Sector Watch: Map", page_icon="🌏")
 
 
-def main() -> None:
-    title_cols = st.columns([5, 1])
-    with title_cols[0]:
-        st.title("Map")
-        st.caption("Click a marker for company detail. Markers cluster at low zoom.")
-    with title_cols[1], st.popover("How to read this map", use_container_width=True):
-        st.markdown(
-            "**Each marker is one verified ANZ AI company.** Colour follows its "
-            "primary sector. The sidebar legend lists the colour groups.\n\n"
-            "**Gold bubbles** are clusters: the number is how many companies "
-            "sit at that zoom level. Click one to zoom in until the markers "
-            "split apart.\n\n"
-            "**Sidebar filters** narrow the map and the table below by sector, "
-            "stage, country, founded year, or name. The Reset button clears "
-            "every filter."
-        )
+@st.fragment
+def _filtered_map_view(all_companies: list[Company]) -> None:
+    """Render the filter sidebar, the map, and the in-view table.
 
-    source = get_source()
-    all_companies = load_companies()
-
-    if source.backend == "yaml":
-        st.info(
-            "Showing seed data from `data/seed/companies.yaml`. Set `SUPABASE_DB_URL` "
-            "to read from the live index."
-        )
-
+    Wrapped in ``@st.fragment`` so changing a filter triggers a partial
+    rerun of just this block — the page title, popover, and brand
+    wordmark stay put instead of flashing.
+    """
     meta = derive_meta(all_companies)
     state = render_sidebar(meta, default_countries=("AU", "NZ"), key_prefix="map_filters")
     render_sector_legend()
@@ -88,6 +71,35 @@ def main() -> None:
         with st.expander(f"Companies without map coordinates ({len(off_map)})"):
             for c in off_map:
                 st.write(f"- **{c.name}** in {c.city or 'unknown city'}, {c.country or '?'}")
+
+
+def main() -> None:
+    title_cols = st.columns([5, 1])
+    with title_cols[0]:
+        st.title("Map")
+        st.caption("Click a marker for company detail. Markers cluster at low zoom.")
+    with title_cols[1], st.popover("How to read this map", use_container_width=True):
+        st.markdown(
+            "**Each marker is one verified ANZ AI company.** Colour follows its "
+            "primary sector. The sidebar legend lists the colour groups.\n\n"
+            "**Gold bubbles** are clusters: the number is how many companies "
+            "sit at that zoom level. Click one to zoom in until the markers "
+            "split apart.\n\n"
+            "**Sidebar filters** narrow the map and the table below by sector, "
+            "stage, country, founded year, or name. The Reset button clears "
+            "every filter."
+        )
+
+    source = get_source()
+    all_companies = load_companies()
+
+    if source.backend == "yaml":
+        st.info(
+            "Showing seed data from `data/seed/companies.yaml`. Set `SUPABASE_DB_URL` "
+            "to read from the live index."
+        )
+
+    _filtered_map_view(all_companies)
 
     render_footer()
 

--- a/dashboard/pages/1_Map.py
+++ b/dashboard/pages/1_Map.py
@@ -29,8 +29,21 @@ render_page_chrome(title="AI Sector Watch: Map", page_icon="🌏")
 
 
 def main() -> None:
-    st.title("Map")
-    st.caption("Click a marker for company detail. Markers cluster at low zoom.")
+    title_cols = st.columns([5, 1])
+    with title_cols[0]:
+        st.title("Map")
+        st.caption("Click a marker for company detail. Markers cluster at low zoom.")
+    with title_cols[1], st.popover("How to read this map", use_container_width=True):
+        st.markdown(
+            "**Each marker is one verified ANZ AI company.** Colour follows its "
+            "primary sector. The sidebar legend lists the colour groups.\n\n"
+            "**Gold bubbles** are clusters: the number is how many companies "
+            "sit at that zoom level. Click one to zoom in until the markers "
+            "split apart.\n\n"
+            "**Sidebar filters** narrow the map and the table below by sector, "
+            "stage, country, founded year, or name. The Reset button clears "
+            "every filter."
+        )
 
     source = get_source()
     all_companies = load_companies()

--- a/dashboard/pages/1_Map.py
+++ b/dashboard/pages/1_Map.py
@@ -78,7 +78,15 @@ def main() -> None:
             width="stretch",
             hide_index=True,
             column_config={
-                "Website": st.column_config.LinkColumn("Website"),
+                "Name": st.column_config.TextColumn("Name", width="medium"),
+                "Country": st.column_config.TextColumn("Country", width="small"),
+                "City": st.column_config.TextColumn("City", width="small"),
+                "Stage": st.column_config.TextColumn("Stage", width="small"),
+                "Founded": st.column_config.NumberColumn("Founded", width="small", format="%d"),
+                "Sectors": st.column_config.TextColumn("Sectors", width="large"),
+                "Website": st.column_config.LinkColumn(
+                    "Website", width="medium", display_text=r"https?://([^/]+).*"
+                ),
             },
         )
     else:

--- a/dashboard/pages/2_Companies.py
+++ b/dashboard/pages/2_Companies.py
@@ -27,8 +27,19 @@ render_page_chrome(title="AI Sector Watch: Companies", page_icon="🏢")
 
 
 def main() -> None:
-    st.title("Companies")
-    st.caption("Every verified company in the index, filterable from the sidebar.")
+    title_cols = st.columns([5, 1])
+    with title_cols[0]:
+        st.title("Companies")
+        st.caption("Every verified company in the index, filterable from the sidebar.")
+    with title_cols[1], st.popover("How to use this directory", use_container_width=True):
+        st.markdown(
+            "**The table** lists every verified ANZ AI company with the data "
+            "the pipeline has gathered. Sortable by any column.\n\n"
+            "**Pick a company** from the dropdown below the table to see "
+            "the full profile: founders, total raised, valuation, "
+            "headcount, and the sources behind those numbers.\n\n"
+            "**Sidebar filters** narrow what is shown. Use Reset to clear them."
+        )
 
     source = get_source()
     all_companies = load_companies()

--- a/dashboard/pages/2_Companies.py
+++ b/dashboard/pages/2_Companies.py
@@ -27,48 +27,6 @@ from dashboard.components.theme import render_page_chrome  # noqa: E402
 render_page_chrome(title="AI Sector Watch: Companies", page_icon="🏢")
 
 
-@st.fragment
-def _filtered_directory(all_companies: list[Company]) -> None:
-    """Render the filter sidebar, the directory table, and the detail card.
-
-    Wrapped in ``@st.fragment`` so filter changes only redraw this block
-    instead of the whole page.
-    """
-    meta = derive_meta(all_companies)
-    state = render_sidebar(meta, default_countries=("AU", "NZ"), key_prefix="company_filters")
-    companies = apply_filters(all_companies, state)
-
-    cols = st.columns(2)
-    cols[0].metric("In view", len(companies))
-    cols[1].metric("Total tracked", len(all_companies))
-
-    rows = companies_to_table_rows(companies)
-    if not rows:
-        st.info("No companies match these filters. Clear one in the sidebar to widen the view.")
-        return
-
-    df = pd.DataFrame(rows)
-    st.dataframe(
-        df,
-        width="stretch",
-        hide_index=True,
-        column_config={
-            "Website": st.column_config.LinkColumn("Website"),
-        },
-    )
-
-    st.subheader("Detail view")
-    options = [c.name for c in companies]
-    selected_name = st.selectbox(
-        "Pick a company",
-        options=options,
-        index=0 if options else None,
-    )
-    if selected_name:
-        company = next(c for c in companies if c.name == selected_name)
-        _render_company_detail(company)
-
-
 def _render_company_detail(company: Company) -> None:
     """Render a single company's detail card."""
     with st.container(border=True):
@@ -138,7 +96,41 @@ def main() -> None:
             "to read from the live index."
         )
 
-    _filtered_directory(all_companies)
+    meta = derive_meta(all_companies)
+    state = render_sidebar(meta, default_countries=("AU", "NZ"), key_prefix="company_filters")
+    companies = apply_filters(all_companies, state)
+
+    cols = st.columns(2)
+    cols[0].metric("In view", len(companies))
+    cols[1].metric("Total tracked", len(all_companies))
+
+    rows = companies_to_table_rows(companies)
+    if not rows:
+        st.info("No companies match these filters. Clear one in the sidebar to widen the view.")
+        render_footer()
+        return
+
+    df = pd.DataFrame(rows)
+    st.dataframe(
+        df,
+        width="stretch",
+        hide_index=True,
+        column_config={
+            "Website": st.column_config.LinkColumn("Website"),
+        },
+    )
+
+    st.subheader("Detail view")
+    options = [c.name for c in companies]
+    selected_name = st.selectbox(
+        "Pick a company",
+        options=options,
+        index=0 if options else None,
+    )
+    if selected_name:
+        company = next(c for c in companies if c.name == selected_name)
+        _render_company_detail(company)
+
     render_footer()
 
 

--- a/dashboard/pages/2_Companies.py
+++ b/dashboard/pages/2_Companies.py
@@ -116,7 +116,15 @@ def main() -> None:
         width="stretch",
         hide_index=True,
         column_config={
-            "Website": st.column_config.LinkColumn("Website"),
+            "Name": st.column_config.TextColumn("Name", width="medium"),
+            "Country": st.column_config.TextColumn("Country", width="small"),
+            "City": st.column_config.TextColumn("City", width="small"),
+            "Stage": st.column_config.TextColumn("Stage", width="small"),
+            "Founded": st.column_config.NumberColumn("Founded", width="small", format="%d"),
+            "Sectors": st.column_config.TextColumn("Sectors", width="large"),
+            "Website": st.column_config.LinkColumn(
+                "Website", width="medium", display_text=r"https?://([^/]+).*"
+            ),
         },
     )
 

--- a/dashboard/pages/2_Companies.py
+++ b/dashboard/pages/2_Companies.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
+from ai_sector_watch.storage.data_source import Company  # noqa: E402
 from dashboard.components.data_loaders import get_source, load_companies  # noqa: E402
 from dashboard.components.filters import (  # noqa: E402
     apply_filters,
@@ -24,6 +25,93 @@ from dashboard.components.footer import render_footer  # noqa: E402
 from dashboard.components.theme import render_page_chrome  # noqa: E402
 
 render_page_chrome(title="AI Sector Watch: Companies", page_icon="🏢")
+
+
+@st.fragment
+def _filtered_directory(all_companies: list[Company]) -> None:
+    """Render the filter sidebar, the directory table, and the detail card.
+
+    Wrapped in ``@st.fragment`` so filter changes only redraw this block
+    instead of the whole page.
+    """
+    meta = derive_meta(all_companies)
+    state = render_sidebar(meta, default_countries=("AU", "NZ"), key_prefix="company_filters")
+    companies = apply_filters(all_companies, state)
+
+    cols = st.columns(2)
+    cols[0].metric("In view", len(companies))
+    cols[1].metric("Total tracked", len(all_companies))
+
+    rows = companies_to_table_rows(companies)
+    if not rows:
+        st.info("No companies match these filters. Clear one in the sidebar to widen the view.")
+        return
+
+    df = pd.DataFrame(rows)
+    st.dataframe(
+        df,
+        width="stretch",
+        hide_index=True,
+        column_config={
+            "Website": st.column_config.LinkColumn("Website"),
+        },
+    )
+
+    st.subheader("Detail view")
+    options = [c.name for c in companies]
+    selected_name = st.selectbox(
+        "Pick a company",
+        options=options,
+        index=0 if options else None,
+    )
+    if selected_name:
+        company = next(c for c in companies if c.name == selected_name)
+        _render_company_detail(company)
+
+
+def _render_company_detail(company: Company) -> None:
+    """Render a single company's detail card."""
+    with st.container(border=True):
+        header = company.name
+        if company.website:
+            header = f"[{company.name}]({company.website})"
+        st.markdown(f"### {header}")
+        st.caption(f"{company.city or 'unknown city'}, {company.country or '?'}")
+        meta_bits = []
+        if company.stage:
+            meta_bits.append(f"**Stage:** {company.stage}")
+        if company.founded_year:
+            meta_bits.append(f"**Founded:** {company.founded_year}")
+        if company.discovery_source:
+            meta_bits.append(f"**Source:** {company.discovery_source}")
+        if meta_bits:
+            st.write(" | ".join(meta_bits))
+        if company.sector_tags:
+            st.write("**Sectors:** " + ", ".join(company.sector_tags))
+        profile_bits = []
+        if company.founders:
+            profile_bits.append(("Founders", ", ".join(company.founders)))
+        total_raised = _format_usd(company.total_raised_usd)
+        if total_raised:
+            profile_bits.append(("Total raised", total_raised))
+        valuation = _format_usd(company.valuation_usd)
+        if valuation:
+            profile_bits.append(("Valuation", valuation))
+        headcount = _format_headcount(company)
+        if headcount:
+            profile_bits.append(("Headcount", headcount))
+        if company.profile_verified_at:
+            profile_bits.append(
+                ("Profile verified", company.profile_verified_at.date().isoformat())
+            )
+        for label, value in profile_bits:
+            st.write(f"**{label}:** {value}")
+        if company.profile_sources:
+            st.write("**Profile sources:**")
+            for source_url in company.profile_sources[:5]:
+                st.markdown(f"- [{source_url}]({source_url})")
+        if company.summary:
+            st.write(company.summary)
 
 
 def main() -> None:
@@ -50,81 +138,7 @@ def main() -> None:
             "to read from the live index."
         )
 
-    meta = derive_meta(all_companies)
-    state = render_sidebar(meta, default_countries=("AU", "NZ"), key_prefix="company_filters")
-    companies = apply_filters(all_companies, state)
-
-    cols = st.columns(2)
-    cols[0].metric("In view", len(companies))
-    cols[1].metric("Total tracked", len(all_companies))
-
-    rows = companies_to_table_rows(companies)
-    if not rows:
-        st.info("No companies match these filters. Clear one in the sidebar to widen the view.")
-        render_footer()
-        return
-
-    df = pd.DataFrame(rows)
-    st.dataframe(
-        df,
-        width="stretch",
-        hide_index=True,
-        column_config={
-            "Website": st.column_config.LinkColumn("Website"),
-        },
-    )
-
-    st.subheader("Detail view")
-    options = [c.name for c in companies]
-    selected_name = st.selectbox(
-        "Pick a company",
-        options=options,
-        index=0 if options else None,
-    )
-    if selected_name:
-        company = next(c for c in companies if c.name == selected_name)
-        with st.container(border=True):
-            header = company.name
-            if company.website:
-                header = f"[{company.name}]({company.website})"
-            st.markdown(f"### {header}")
-            st.caption(f"{company.city or 'unknown city'}, {company.country or '?'}")
-            meta_bits = []
-            if company.stage:
-                meta_bits.append(f"**Stage:** {company.stage}")
-            if company.founded_year:
-                meta_bits.append(f"**Founded:** {company.founded_year}")
-            if company.discovery_source:
-                meta_bits.append(f"**Source:** {company.discovery_source}")
-            if meta_bits:
-                st.write(" | ".join(meta_bits))
-            if company.sector_tags:
-                st.write("**Sectors:** " + ", ".join(company.sector_tags))
-            profile_bits = []
-            if company.founders:
-                profile_bits.append(("Founders", ", ".join(company.founders)))
-            total_raised = _format_usd(company.total_raised_usd)
-            if total_raised:
-                profile_bits.append(("Total raised", total_raised))
-            valuation = _format_usd(company.valuation_usd)
-            if valuation:
-                profile_bits.append(("Valuation", valuation))
-            headcount = _format_headcount(company)
-            if headcount:
-                profile_bits.append(("Headcount", headcount))
-            if company.profile_verified_at:
-                profile_bits.append(
-                    ("Profile verified", company.profile_verified_at.date().isoformat())
-                )
-            for label, value in profile_bits:
-                st.write(f"**{label}:** {value}")
-            if company.profile_sources:
-                st.write("**Profile sources:**")
-                for source_url in company.profile_sources[:5]:
-                    st.markdown(f"- [{source_url}]({source_url})")
-            if company.summary:
-                st.write(company.summary)
-
+    _filtered_directory(all_companies)
     render_footer()
 
 

--- a/dashboard/pages/3_News.py
+++ b/dashboard/pages/3_News.py
@@ -23,11 +23,22 @@ render_page_chrome(title="AI Sector Watch: News", page_icon="📰")
 
 
 def main() -> None:
-    st.title("News")
-    st.caption(
-        "Chronological feed of relevant funding, launches, hires, and "
-        "partnerships from the past week's pipeline run."
-    )
+    title_cols = st.columns([5, 1])
+    with title_cols[0]:
+        st.title("News")
+        st.caption(
+            "Chronological feed of relevant funding, launches, hires, and "
+            "partnerships from the past week's pipeline run."
+        )
+    with title_cols[1], st.popover("Where do these come from", use_container_width=True):
+        st.markdown(
+            "Items are auto-extracted from a curated set of ANZ AI sources "
+            "every Monday morning (Sydney time), then linked to the "
+            "companies they mention.\n\n"
+            "**Headlines** open the original story in a new tab. "
+            "**Mentions** lists the companies the pipeline matched against "
+            "the index. The full source list lives in `docs/sources.md`."
+        )
 
     source = get_source()
     news = load_news(limit=100)

--- a/dashboard/static/styles.css
+++ b/dashboard/static/styles.css
@@ -1,6 +1,8 @@
 /* AI Sector Watch design system. See docs/design-system.md for tokens + rationale. */
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+/* Inter and JetBrains Mono are loaded by the [theme] font/codeFont URL syntax in
+   .streamlit/config.toml so they apply to both the styled body and the native
+   Streamlit chrome (toolbar, deploy modal). No CSS @import needed here. */
 
 :root {
   --aisw-bg: #0B0F14;

--- a/dashboard/static/styles.css
+++ b/dashboard/static/styles.css
@@ -462,6 +462,15 @@ hr, [data-testid="stDivider"] {
   line-height: 1.6;
 }
 
+/* First-run welcome banner on Home (st.container(key="aisw_intro_hint")). */
+.st-key-aisw_intro_hint {
+  background: rgba(244, 183, 64, 0.10);
+  border: 1px solid rgba(244, 183, 64, 0.42);
+  border-radius: var(--aisw-radius-lg);
+  padding: 14px 18px;
+  margin-bottom: 1.25rem;
+}
+
 /* Streamlit chrome we don't want */
 [data-testid="stDecoration"] { display: none !important; }
 [data-testid="stToolbar"] { display: none !important; }

--- a/dashboard/streamlit_app.py
+++ b/dashboard/streamlit_app.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 
 import streamlit as st
+import streamlit_shadcn_ui as ui
+from streamlit_extras.stylable_container import stylable_container
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
@@ -20,6 +22,37 @@ from dashboard.components.footer import render_footer  # noqa: E402
 from dashboard.components.theme import render_page_chrome  # noqa: E402
 
 render_page_chrome(title="AI Sector Watch", page_icon="🌏")
+
+_INTRO_DISMISSED_KEY = "aisw_intro_dismissed"
+
+
+def _render_intro_hint() -> None:
+    """Render a one-time welcome banner the user can dismiss."""
+    if st.session_state.get(_INTRO_DISMISSED_KEY):
+        return
+    with stylable_container(
+        key="aisw_intro_hint",
+        css_styles="""
+        {
+          background: rgba(244, 183, 64, 0.10);
+          border: 1px solid rgba(244, 183, 64, 0.42);
+          border-radius: 8px;
+          padding: 14px 18px;
+          margin-bottom: 1.25rem;
+        }
+        """,
+    ):
+        cols = st.columns([20, 1])
+        with cols[0]:
+            st.markdown(
+                "**Welcome.** Use the sidebar to jump between pages, or pick a path "
+                "below. Click any marker on the map for the full company profile, "
+                "and use the filters in the sidebar to narrow by sector, stage, or city."
+            )
+        with cols[1]:
+            if st.button("✕", key="aisw_intro_dismiss", help="Dismiss this hint"):
+                st.session_state[_INTRO_DISMISSED_KEY] = True
+                st.rerun()
 
 
 def main() -> None:
@@ -32,19 +65,35 @@ def main() -> None:
         "updated weekly by an automated agent pipeline."
     )
 
+    _render_intro_hint()
+
     if source.backend == "yaml":
         st.info("Reading from the local seed YAML. Set `SUPABASE_DB_URL` to switch to live data.")
 
+    au_count = sum(1 for c in companies if c.country == "AU")
+    nz_count = sum(1 for c in companies if c.country == "NZ")
     col1, col2, col3 = st.columns(3)
-    col1.metric("Tracked", len(companies))
-    col2.metric(
-        "Australia",
-        sum(1 for c in companies if c.country == "AU"),
-    )
-    col3.metric(
-        "New Zealand",
-        sum(1 for c in companies if c.country == "NZ"),
-    )
+    with col1:
+        ui.metric_card(
+            title="Tracked companies",
+            content=f"{len(companies):,}",
+            description="Verified across the index",
+            key="aisw_metric_tracked",
+        )
+    with col2:
+        ui.metric_card(
+            title="Australia",
+            content=f"{au_count:,}",
+            description="Sydney, Melbourne, Brisbane, and beyond",
+            key="aisw_metric_au",
+        )
+    with col3:
+        ui.metric_card(
+            title="New Zealand",
+            content=f"{nz_count:,}",
+            description="Auckland, Wellington, Christchurch",
+            key="aisw_metric_nz",
+        )
 
     st.divider()
 

--- a/dashboard/streamlit_app.py
+++ b/dashboard/streamlit_app.py
@@ -10,8 +10,6 @@ import sys
 from pathlib import Path
 
 import streamlit as st
-import streamlit_shadcn_ui as ui
-from streamlit_extras.stylable_container import stylable_container
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
@@ -27,21 +25,14 @@ _INTRO_DISMISSED_KEY = "aisw_intro_dismissed"
 
 
 def _render_intro_hint() -> None:
-    """Render a one-time welcome banner the user can dismiss."""
+    """Render a one-time welcome banner the user can dismiss.
+
+    Uses ``st.container(key=...)`` so the styling lives in
+    ``dashboard/static/styles.css`` against the matching ``.st-key-`` selector.
+    """
     if st.session_state.get(_INTRO_DISMISSED_KEY):
         return
-    with stylable_container(
-        key="aisw_intro_hint",
-        css_styles="""
-        {
-          background: rgba(244, 183, 64, 0.10);
-          border: 1px solid rgba(244, 183, 64, 0.42);
-          border-radius: 8px;
-          padding: 14px 18px;
-          margin-bottom: 1.25rem;
-        }
-        """,
-    ):
+    with st.container(key="aisw_intro_hint"):
         cols = st.columns([20, 1])
         with cols[0]:
             st.markdown(
@@ -73,27 +64,9 @@ def main() -> None:
     au_count = sum(1 for c in companies if c.country == "AU")
     nz_count = sum(1 for c in companies if c.country == "NZ")
     col1, col2, col3 = st.columns(3)
-    with col1:
-        ui.metric_card(
-            title="Tracked companies",
-            content=f"{len(companies):,}",
-            description="Verified across the index",
-            key="aisw_metric_tracked",
-        )
-    with col2:
-        ui.metric_card(
-            title="Australia",
-            content=f"{au_count:,}",
-            description="Sydney, Melbourne, Brisbane, and beyond",
-            key="aisw_metric_au",
-        )
-    with col3:
-        ui.metric_card(
-            title="New Zealand",
-            content=f"{nz_count:,}",
-            description="Auckland, Wellington, Christchurch",
-            key="aisw_metric_nz",
-        )
+    col1.metric("Tracked companies", f"{len(companies):,}")
+    col2.metric("Australia", f"{au_count:,}")
+    col3.metric("New Zealand", f"{nz_count:,}")
 
     st.divider()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dashboard = [
-    "streamlit>=1.39.0",
+    "streamlit>=1.45.0",
     "streamlit-folium>=0.22.0",
+    "streamlit-extras>=0.4.7",
+    "streamlit-shadcn-ui>=0.1.18",
     "folium>=0.17.0",
     "pandas>=2.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,6 @@ dependencies = [
 dashboard = [
     "streamlit>=1.45.0",
     "streamlit-folium>=0.22.0",
-    "streamlit-extras>=0.4.7",
-    "streamlit-shadcn-ui>=0.1.18",
     "folium>=0.17.0",
     "pandas>=2.2.0",
 ]

--- a/src/ai_sector_watch/discovery/taxonomy.py
+++ b/src/ai_sector_watch/discovery/taxonomy.py
@@ -57,6 +57,24 @@ _GROUP_COLOURS: dict[str, str] = {
     "creative": "pink",
 }
 
+# Hex equivalents tuned for the dark-theme background (#0B0F14). The folium
+# named colours above feed `folium.Icon`, which is being phased out for a
+# `DivIcon` circle on the dashboard map. The `DivIcon` HTML needs an actual
+# CSS hex value, and the dashboard sector legend reuses the same map so the
+# legend swatches and map markers stay in sync.
+_GROUP_HEX: dict[str, str] = {
+    "infra": "#4F8DFF",
+    "vertical": "#4ADE80",
+    "robotics": "#FB923C",
+    "science": "#C084FC",
+    "climate": "#34D399",
+    "defence": "#94A3B8",
+    "dev_tools": "#67E8F9",
+    "agents": "#F87171",
+    "creative": "#F472B6",
+}
+_DEFAULT_HEX = "#8B95A6"
+
 
 def _sector(tag: str, label: str, group: str) -> Sector:
     return Sector(tag=tag, label=label, group=group, colour=_GROUP_COLOURS[group])
@@ -120,3 +138,28 @@ def primary_sector_colour(tags: list[str]) -> str:
         if colour:
             return colour
     return "gray"
+
+
+def hex_for_sector(tag: str, *, default: str = _DEFAULT_HEX) -> str:
+    """Return the hex colour for a sector tag, falling back to ``default``."""
+    sector = get_sector(tag)
+    if sector is None:
+        return default
+    return _GROUP_HEX.get(sector.group, default)
+
+
+def primary_sector_hex(tags: list[str], *, default: str = _DEFAULT_HEX) -> str:
+    """Pick a single hex colour for a marker that has multiple sector tags."""
+    for tag in tags:
+        sector = get_sector(tag)
+        if sector is None:
+            continue
+        hex_value = _GROUP_HEX.get(sector.group)
+        if hex_value:
+            return hex_value
+    return default
+
+
+def hex_for_group(group: str, *, default: str = _DEFAULT_HEX) -> str:
+    """Return the hex colour for a sector colour group."""
+    return _GROUP_HEX.get(group, default)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -138,7 +138,13 @@ def test_companies_to_table_rows_keeps_missing_founded_year_null() -> None:
     assert rows[0]["Founded"] is None
 
 
-def test_companies_to_table_rows_includes_profile_fields() -> None:
+def test_companies_to_table_rows_excludes_sparse_profile_fields() -> None:
+    """Profile-enrichment fields surface on the per-company detail card only.
+
+    Coverage is sparse, so showing them as table columns produces a wall of
+    blanks. The detail view on the Companies page renders them per company
+    where it actually has data.
+    """
     rows = companies_to_table_rows(
         [
             _make(
@@ -151,10 +157,13 @@ def test_companies_to_table_rows_includes_profile_fields() -> None:
         ]
     )
 
-    assert rows[0]["Founders"] == "Ada Lovelace, Grace Hopper"
-    assert rows[0]["Raised"] == "US$25M"
-    assert rows[0]["Valuation"] == "US$1B"
-    assert rows[0]["Headcount"] == "50-100"
+    for dropped in ("Founders", "Raised", "Valuation", "Headcount", "Verified"):
+        assert dropped not in rows[0]
+
+
+def test_companies_to_table_rows_renders_human_stage_label() -> None:
+    rows = companies_to_table_rows([_make(stage="series_a")])
+    assert rows[0]["Stage"] == "Series A"
 
 
 def test_full_pipeline_against_yaml_source() -> None:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from ai_sector_watch.discovery.taxonomy import (
     SECTOR_GROUPS,
     SECTOR_TAGS,
@@ -9,10 +11,15 @@ from ai_sector_watch.discovery.taxonomy import (
     STAGES,
     colour_for_sector,
     get_sector,
+    hex_for_group,
+    hex_for_sector,
     is_valid_sector,
     is_valid_stage,
     primary_sector_colour,
+    primary_sector_hex,
 )
+
+_HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
 
 
 def test_all_prd_sectors_present() -> None:
@@ -84,5 +91,34 @@ def test_primary_sector_colour_handles_empty_and_unknown() -> None:
     assert primary_sector_colour([]) == "gray"
     assert primary_sector_colour(["nonsense"]) == "gray"
     assert primary_sector_colour(["nonsense", "agents_and_orchestration"]) == colour_for_sector(
+        "agents_and_orchestration"
+    )
+
+
+def test_hex_for_sector_returns_six_digit_hex() -> None:
+    for tag in SECTOR_TAGS:
+        assert _HEX_RE.match(hex_for_sector(tag)), tag
+
+
+def test_hex_for_sector_unknown_falls_back_to_default() -> None:
+    assert hex_for_sector("not-a-real-sector") == hex_for_sector("not-a-real-sector")
+    assert hex_for_sector("not-a-real-sector", default="#000000") == "#000000"
+
+
+def test_hex_for_group_covers_every_group() -> None:
+    for group in SECTOR_GROUPS:
+        assert _HEX_RE.match(hex_for_group(group)), group
+
+
+def test_primary_sector_hex_uses_first_known_tag() -> None:
+    chosen = primary_sector_hex(["foundation_models", "agents_and_orchestration"])
+    assert chosen == hex_for_sector("foundation_models")
+
+
+def test_primary_sector_hex_handles_empty_and_unknown() -> None:
+    fallback = primary_sector_hex([])
+    assert _HEX_RE.match(fallback)
+    assert primary_sector_hex(["nonsense"]) == fallback
+    assert primary_sector_hex(["nonsense", "agents_and_orchestration"]) == hex_for_sector(
         "agents_and_orchestration"
     )


### PR DESCRIPTION
Second of two PRs against #58 (PR1 merged in #59). Visual + UX polish.

## Summary

Seven focused commits, each one concern:

1. **chore(deps)** - bump streamlit to 1.45 (unlocks the new font URL syntax + stable @st.fragment); add streamlit-extras and streamlit-shadcn-ui to the dashboard extras.
2. **style(dashboard)** - load Inter and JetBrains Mono via the new `[theme]` font URL syntax in `.streamlit/config.toml` so they apply to native Streamlit chrome (toolbar, deploy modal) as well as the styled body. Drop the now-redundant `@import` from styles.css.
3. **feat(taxonomy)** - add `_GROUP_HEX`, `hex_for_sector`, `primary_sector_hex`, `hex_for_group` alongside the existing folium-named-colour helpers. Hex values tuned for the dark-theme background. Tests added.
4. **feat(dashboard)** - replace `folium.Icon` (default Leaflet teardrops) with `folium.DivIcon` circles filled with the sector hex. Custom `MarkerCluster` `icon_create_function` produces gold cluster bubbles in the brand palette instead of the default green/yellow/red. Sector legend chips switch to the same hex map so they stay in lock-step with the markers.
5. **feat(dashboard)** - polish Home with `streamlit-shadcn-ui` metric cards (with description lines) and a dismissible welcome banner using `streamlit-extras` `stylable_container`.
6. **feat(dashboard)** - inline help popovers (`How to read this map`, `How to use this directory`, `Where do these come from`) next to each page title, plus `help=` tooltips on the founded year slider and name search input.
7. **perf(dashboard)** - wrap the filter+render block on Map and Companies with `@st.fragment` so changing a filter only redraws that block. The data was already cached in PR1; this kills the wordmark/sidebar flash on every multiselect toggle.

## Visual notes for review

- **Map markers** are now small filled circles, sector-coloured. Cluster bubbles are gold. The popup styling and the sidebar legend palette were updated together so nothing reads mismatched.
- **Home metric cards** use shadcn-ui. shadcn ships its own React/Tailwind component in an iframe, so its dark-mode rendering is largely out of our control. If the cards look off in dark mode after this lands, the fix is small (revert to `st.metric` with the existing custom CSS, which is already polished). Easy follow-up if needed.
- **First-run banner** appears once per session and disappears on dismiss; the dismissal is held in `st.session_state`.

## Test plan

- [x] `pytest -q` (78 pass, 2 live-DB skips)
- [x] `ruff check .` clean
- [x] `black --check .` clean
- [x] DivIcon HTML appears in the rendered folium output with sector-specific hex fills
- [x] All four dashboard entry points compile cleanly
- [ ] Manual: open the map; markers are coloured circles, cluster bubbles are gold
- [ ] Manual: toggle a filter; the wordmark, sidebar nav, and page title do not flash
- [ ] Manual: open each page popover and verify the copy reads cleanly
- [ ] Manual: dismiss the home banner; reload, confirm it stays dismissed for the session

## Risk notes

- streamlit-shadcn-ui adds a small JS bundle per metric card. If first-paint latency on Azure regresses, swap the three `ui.metric_card` calls back to `st.metric`.
- The `_GROUP_COLOURS` folium-named map stays in place for backwards compatibility (still imported by `colour_for_sector` / `primary_sector_colour`), even though the dashboard no longer uses it.

Closes #58 (with PR1 in #59).