### PR TITLE
[#64] Phase 2A: Companies directory with detail pages

### DIFF
--- a/web/src/app/api/companies/route.ts
+++ b/web/src/app/api/companies/route.ts
@@ -1,121 +1,15 @@
-// GET /api/companies?statuses=verified
-//
-// Mirrors SupabaseSource.list_companies() in
-// src/ai_sector_watch/storage/data_source.py. Returns the verified set by default.
+// GET /api/companies — verified companies (mirrors SupabaseSource.list_companies).
 
 import { NextResponse } from "next/server";
 
-import { sql } from "@/lib/db";
-import type { Company, FundingEvent } from "@/lib/types";
+import { listVerifiedCompanies } from "@/lib/companies-server";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-type Row = Record<string, unknown>;
-
-function toNumber(value: unknown): number | null {
-  if (value === null || value === undefined) return null;
-  if (typeof value === "number") return value;
-  if (typeof value === "string") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
-}
-
-function toIsoDate(value: unknown): string | null {
-  if (value === null || value === undefined) return null;
-  if (value instanceof Date) return value.toISOString();
-  if (typeof value === "string") return value;
-  return null;
-}
-
-function toStringArray(value: unknown): string[] {
-  if (Array.isArray(value)) return value.map((v) => String(v));
-  return [];
-}
-
-function buildFunding(row: Row): FundingEvent | null {
-  if (!row.latest_funding_id) return null;
-  return {
-    id: String(row.latest_funding_id),
-    announced_on: toIsoDate(row.latest_funding_announced_on),
-    stage: (row.latest_funding_stage as string | null) ?? null,
-    amount_usd: toNumber(row.latest_funding_amount_usd),
-    currency_raw: (row.latest_funding_currency_raw as string | null) ?? null,
-    lead_investor: (row.latest_funding_lead_investor as string | null) ?? null,
-    investors: toStringArray(row.latest_funding_investors),
-    source_url: (row.latest_funding_source_url as string | null) ?? null,
-  };
-}
-
-function buildCompany(row: Row): Company {
-  return {
-    id: String(row.id),
-    name: row.name as string,
-    country: (row.country as string | null) ?? null,
-    city: (row.city as string | null) ?? null,
-    lat: toNumber(row.lat),
-    lon: toNumber(row.lon),
-    website: (row.website as string | null) ?? null,
-    sector_tags: toStringArray(row.sector_tags),
-    stage: (row.stage as string | null) ?? null,
-    founded_year: toNumber(row.founded_year),
-    summary: (row.summary as string | null) ?? null,
-    discovery_status: row.discovery_status as string,
-    discovery_source: (row.discovery_source as string | null) ?? null,
-    founders: toStringArray(row.founders),
-    total_raised_usd: toNumber(row.total_raised_usd),
-    total_raised_currency_raw: (row.total_raised_currency_raw as string | null) ?? null,
-    total_raised_as_of: toIsoDate(row.total_raised_as_of),
-    total_raised_source_url: (row.total_raised_source_url as string | null) ?? null,
-    valuation_usd: toNumber(row.valuation_usd),
-    valuation_currency_raw: (row.valuation_currency_raw as string | null) ?? null,
-    valuation_as_of: toIsoDate(row.valuation_as_of),
-    valuation_source_url: (row.valuation_source_url as string | null) ?? null,
-    headcount_estimate: toNumber(row.headcount_estimate),
-    headcount_min: toNumber(row.headcount_min),
-    headcount_max: toNumber(row.headcount_max),
-    headcount_as_of: toIsoDate(row.headcount_as_of),
-    headcount_source_url: (row.headcount_source_url as string | null) ?? null,
-    profile_confidence: toNumber(row.profile_confidence),
-    profile_sources: toStringArray(row.profile_sources),
-    profile_verified_at: toIsoDate(row.profile_verified_at),
-    latest_funding_event: buildFunding(row),
-  };
-}
-
-export async function GET(request: Request) {
-  const url = new URL(request.url);
-  const statusesParam = url.searchParams.getAll("statuses");
-  const statuses = statusesParam.length > 0 ? statusesParam : ["verified"];
-
+export async function GET() {
   try {
-    const rows = await sql<Row[]>`
-      SELECT
-          c.*,
-          fe.id AS latest_funding_id,
-          fe.announced_on AS latest_funding_announced_on,
-          fe.stage AS latest_funding_stage,
-          fe.amount_usd AS latest_funding_amount_usd,
-          fe.currency_raw AS latest_funding_currency_raw,
-          fe.lead_investor AS latest_funding_lead_investor,
-          fe.investors AS latest_funding_investors,
-          fe.source_url AS latest_funding_source_url
-      FROM companies c
-      LEFT JOIN LATERAL (
-          SELECT id, announced_on, stage, amount_usd, currency_raw,
-                 lead_investor, investors, source_url, created_at
-          FROM funding_events
-          WHERE company_id = c.id
-          ORDER BY announced_on DESC NULLS LAST, created_at DESC
-          LIMIT 1
-      ) fe ON TRUE
-      WHERE c.discovery_status = ANY(${statuses})
-      ORDER BY c.name
-    `;
-
-    const companies = rows.map(buildCompany);
+    const companies = await listVerifiedCompanies();
     return NextResponse.json({ companies });
   } catch (err) {
     console.error("GET /api/companies failed", err);

--- a/web/src/app/companies/[slug]/page.tsx
+++ b/web/src/app/companies/[slug]/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { CompanyProfile } from "@/components/companies/CompanyProfile";
+import { listVerifiedCompanies } from "@/lib/companies-server";
+import { findBySlug } from "@/lib/slug";
+
+export const dynamic = "force-dynamic";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  try {
+    const companies = await listVerifiedCompanies();
+    const company = findBySlug(companies, slug);
+    if (!company) return { title: "Company not found" };
+    return {
+      title: company.name,
+      description: company.summary?.slice(0, 160) ?? `${company.name} on AI Sector Watch.`,
+    };
+  } catch {
+    return { title: "Company" };
+  }
+}
+
+export default async function CompanyDetailPage({ params }: PageProps) {
+  const { slug } = await params;
+  const companies = await listVerifiedCompanies();
+  const company = findBySlug(companies, slug);
+  if (!company) notFound();
+  return <CompanyProfile company={company} />;
+}

--- a/web/src/app/companies/page.tsx
+++ b/web/src/app/companies/page.tsx
@@ -1,17 +1,32 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 
-import { StubPage } from "@/components/StubPage";
+import { CompaniesDirectory } from "@/components/companies/CompaniesDirectory";
 
 export const metadata: Metadata = {
   title: "Companies",
+  description: "Every verified ANZ AI startup we track.",
 };
 
 export default function CompaniesPage() {
   return (
-    <StubPage
-      eyebrow="Browse"
-      title="Companies"
-      body="A searchable directory of every verified ANZ AI startup we track, with a detail layout for each profile. Stub for now: the prototype focuses on the map page first."
-    />
+    <Suspense fallback={<DirectoryShell />}>
+      <CompaniesDirectory />
+    </Suspense>
+  );
+}
+
+function DirectoryShell() {
+  return (
+    <section className="mx-auto w-full max-w-[1200px] px-5 py-10">
+      <div>
+        <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-text-subtle">
+          Browse
+        </div>
+        <h1 className="mt-1 text-3xl font-semibold tracking-tight text-text sm:text-4xl">
+          Companies
+        </h1>
+      </div>
+    </section>
   );
 }

--- a/web/src/components/companies/CompaniesDirectory.tsx
+++ b/web/src/components/companies/CompaniesDirectory.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink } from "lucide-react";
+
+import { CompaniesFilterBar } from "./CompaniesFilterBar";
+import {
+  applyFilters,
+  deriveMeta,
+  filtersToParams,
+  paramsToFilters,
+} from "@/lib/filters";
+import { primarySectorHex, sectorLabel } from "@/lib/taxonomy";
+import { formatHeadcount, formatStage, formatUsd } from "@/lib/format";
+import { slugFor } from "@/lib/slug";
+import { cn } from "@/lib/cn";
+import type { Company } from "@/lib/types";
+
+type SortKey = "name" | "founded" | "raised" | "headcount";
+type SortDir = "asc" | "desc";
+
+export function CompaniesDirectory() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [companies, setCompanies] = useState<Company[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/companies")
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((data: { companies: Company[] }) => {
+        if (!cancelled) setCompanies(data.companies);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const meta = useMemo(() => deriveMeta(companies ?? []), [companies]);
+  const filterState = useMemo(
+    () => paramsToFilters(new URLSearchParams(searchParams.toString())),
+    [searchParams],
+  );
+  const sortKey = (searchParams.get("sort") as SortKey) || "name";
+  const sortDir = (searchParams.get("dir") as SortDir) || "asc";
+
+  const filtered = useMemo(
+    () => applyFilters(companies ?? [], filterState),
+    [companies, filterState],
+  );
+
+  const sorted = useMemo(() => sortCompanies(filtered, sortKey, sortDir), [filtered, sortKey, sortDir]);
+
+  const updateUrl = useCallback(
+    (overrides: { state?: typeof filterState; sort?: SortKey; dir?: SortDir }) => {
+      const next = filtersToParams(overrides.state ?? filterState);
+      const finalSort = overrides.sort ?? sortKey;
+      const finalDir = overrides.dir ?? sortDir;
+      if (finalSort !== "name") next.set("sort", finalSort);
+      if (finalDir !== "asc") next.set("dir", finalDir);
+      const qs = next.toString();
+      router.replace(qs ? `/companies?${qs}` : "/companies", { scroll: false });
+    },
+    [filterState, sortKey, sortDir, router],
+  );
+
+  const onSort = useCallback(
+    (key: SortKey) => {
+      const nextDir: SortDir = sortKey === key ? (sortDir === "asc" ? "desc" : "asc") : "asc";
+      updateUrl({ sort: key, dir: nextDir });
+    },
+    [sortKey, sortDir, updateUrl],
+  );
+
+  return (
+    <section className="mx-auto w-full max-w-[1200px] px-5 py-10">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-text-subtle">
+            Browse
+          </div>
+          <h1 className="mt-1 text-3xl font-semibold tracking-tight text-text sm:text-4xl">
+            Companies
+          </h1>
+          <p className="mt-2 text-[14px] text-text-muted">
+            Every verified ANZ AI startup we track. Filter, sort, and click through to a profile.
+          </p>
+        </div>
+        <div className="text-[12px] text-text-muted">
+          <span className="font-mono tabular-nums text-text">{sorted.length}</span>
+          {companies && (
+            <span>
+              {" "}
+              of <span className="font-mono tabular-nums">{companies.length}</span> companies
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-5">
+        <CompaniesFilterBar
+          state={filterState}
+          meta={meta}
+          onChange={(next) => updateUrl({ state: next })}
+        />
+      </div>
+
+      {error && (
+        <div className="mt-6 rounded-md border border-error/40 bg-surface px-4 py-3 text-[13px] text-error">
+          Failed to load companies: {error}
+        </div>
+      )}
+
+      {!error && companies === null && (
+        <div className="mt-6 rounded-md border border-border bg-surface px-4 py-3 text-[13px] text-text-muted">
+          Loading companies...
+        </div>
+      )}
+
+      {!error && companies !== null && sorted.length === 0 && (
+        <div className="mt-6 rounded-md border border-border bg-surface px-4 py-8 text-center text-[13px] text-text-muted">
+          No companies match the current filters.
+        </div>
+      )}
+
+      {!error && sorted.length > 0 && (
+        <>
+          {/* Desktop table */}
+          <div className="aisw-scroll mt-5 hidden overflow-x-auto rounded-xl border border-border bg-surface/40 lg:block">
+            <table className="w-full text-[13px]">
+              <thead className="border-b border-border text-text-muted">
+                <tr className="text-left">
+                  <SortableTh label="Name" active={sortKey} dir={sortDir} field="name" onSort={onSort} />
+                  <th className="px-4 py-2 font-medium">Stage</th>
+                  <SortableTh label="Founded" active={sortKey} dir={sortDir} field="founded" onSort={onSort} />
+                  <SortableTh label="Total raised" active={sortKey} dir={sortDir} field="raised" onSort={onSort} />
+                  <SortableTh label="Headcount" active={sortKey} dir={sortDir} field="headcount" onSort={onSort} />
+                  <th className="px-4 py-2 font-medium">Sectors</th>
+                  <th className="px-4 py-2 font-medium">Location</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map((c) => {
+                  const slug = slugFor(c, companies ?? [c]);
+                  const accent = primarySectorHex(c.sector_tags);
+                  return (
+                    <tr
+                      key={c.id}
+                      className="border-b border-border last:border-0 transition-colors hover:bg-surface/80"
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className="h-2 w-2 shrink-0 rounded-full"
+                            style={{ background: accent }}
+                            aria-hidden
+                          />
+                          <Link
+                            href={`/companies/${slug}`}
+                            className="font-semibold text-text hover:text-accent"
+                          >
+                            {c.name}
+                          </Link>
+                          {c.website && (
+                            <a
+                              href={c.website}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              onClick={(e) => e.stopPropagation()}
+                              className="text-text-muted hover:text-accent"
+                              aria-label={`${c.name} website`}
+                            >
+                              <ExternalLink className="h-3 w-3" />
+                            </a>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-text-muted">{formatStage(c.stage) ?? "-"}</td>
+                      <td className="px-4 py-3 text-text-muted tabular-nums">
+                        {c.founded_year ?? "-"}
+                      </td>
+                      <td className="px-4 py-3 tabular-nums text-text">
+                        {formatUsd(c.total_raised_usd) ?? "-"}
+                      </td>
+                      <td className="px-4 py-3 text-text-muted tabular-nums">
+                        {formatHeadcount(c) ?? "-"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex flex-wrap gap-1">
+                          {c.sector_tags.slice(0, 2).map((tag) => (
+                            <span
+                              key={tag}
+                              className="rounded border border-border bg-surface-2 px-1.5 py-0.5 text-[11px] text-text-muted"
+                            >
+                              {sectorLabel(tag)}
+                            </span>
+                          ))}
+                          {c.sector_tags.length > 2 && (
+                            <span className="text-[11px] text-text-subtle">
+                              +{c.sector_tags.length - 2}
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-text-muted">
+                        {[c.city, c.country].filter(Boolean).join(", ") || "-"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile / tablet cards */}
+          <ul className="mt-5 grid grid-cols-1 gap-3 lg:hidden sm:grid-cols-2">
+            {sorted.map((c) => {
+              const slug = slugFor(c, companies ?? [c]);
+              const accent = primarySectorHex(c.sector_tags);
+              return (
+                <li key={c.id} className="overflow-hidden rounded-xl border border-border bg-surface">
+                  <div className="h-1 w-full" style={{ background: accent }} aria-hidden />
+                  <Link href={`/companies/${slug}`} className="block px-4 py-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <h3 className="text-[15px] font-semibold text-text">{c.name}</h3>
+                      <span className="text-[11px] text-text-subtle whitespace-nowrap">
+                        {[c.city, c.country].filter(Boolean).join(", ")}
+                      </span>
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-[12px] text-text-muted tabular-nums">
+                      {formatStage(c.stage) && <span>{formatStage(c.stage)}</span>}
+                      {c.founded_year !== null && <span>Founded {c.founded_year}</span>}
+                      {formatUsd(c.total_raised_usd) && (
+                        <span className="text-text">{formatUsd(c.total_raised_usd)}</span>
+                      )}
+                      {formatHeadcount(c) && <span>{formatHeadcount(c)} people</span>}
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-1">
+                      {c.sector_tags.slice(0, 3).map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded border border-border bg-surface-2 px-1.5 py-0.5 text-[11px] text-text-muted"
+                        >
+                          {sectorLabel(tag)}
+                        </span>
+                      ))}
+                      {c.sector_tags.length > 3 && (
+                        <span className="text-[11px] text-text-subtle">
+                          +{c.sector_tags.length - 3}
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}
+
+function SortableTh({
+  label,
+  active,
+  dir,
+  field,
+  onSort,
+}: {
+  label: string;
+  active: SortKey;
+  dir: SortDir;
+  field: SortKey;
+  onSort: (k: SortKey) => void;
+}) {
+  const isActive = active === field;
+  const Icon = !isActive ? ArrowUpDown : dir === "asc" ? ArrowUp : ArrowDown;
+  return (
+    <th className="px-4 py-2 font-medium">
+      <button
+        type="button"
+        onClick={() => onSort(field)}
+        className={cn(
+          "inline-flex items-center gap-1 transition-colors",
+          isActive ? "text-text" : "text-text-muted hover:text-text",
+        )}
+      >
+        {label}
+        <Icon className="h-3 w-3" />
+      </button>
+    </th>
+  );
+}
+
+function sortCompanies(items: Company[], key: SortKey, dir: SortDir): Company[] {
+  const mult = dir === "asc" ? 1 : -1;
+  const cmpNullable = (a: number | null, b: number | null): number => {
+    if (a === null && b === null) return 0;
+    if (a === null) return 1; // nulls last
+    if (b === null) return -1;
+    return a - b;
+  };
+
+  const sorted = [...items];
+  switch (key) {
+    case "founded":
+      sorted.sort((a, b) => mult * cmpNullable(a.founded_year, b.founded_year));
+      break;
+    case "raised":
+      sorted.sort((a, b) => mult * cmpNullable(a.total_raised_usd, b.total_raised_usd));
+      break;
+    case "headcount":
+      sorted.sort((a, b) => mult * cmpNullable(headcountForSort(a), headcountForSort(b)));
+      break;
+    case "name":
+    default:
+      sorted.sort((a, b) => mult * a.name.localeCompare(b.name));
+  }
+  return sorted;
+}
+
+function headcountForSort(c: Company): number | null {
+  if (c.headcount_estimate !== null) return c.headcount_estimate;
+  if (c.headcount_max !== null) return c.headcount_max;
+  if (c.headcount_min !== null) return c.headcount_min;
+  return null;
+}

--- a/web/src/components/companies/CompaniesFilterBar.tsx
+++ b/web/src/components/companies/CompaniesFilterBar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { SECTORS, STAGE_LABELS, STAGES } from "@/lib/taxonomy";
+import {
+  EMPTY_FILTERS,
+  type FilterMeta,
+  type FilterState,
+  isFilterActive,
+} from "@/lib/filters";
+import {
+  MultiSelect,
+  ResetButton,
+  SearchInput,
+  YearRange,
+} from "@/components/filters/primitives";
+
+interface Props {
+  state: FilterState;
+  meta: FilterMeta;
+  onChange: (next: FilterState) => void;
+}
+
+export function CompaniesFilterBar({ state, meta, onChange }: Props) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-xl border border-border bg-surface/60 px-3 py-2.5">
+      <SearchInput
+        value={state.nameQuery}
+        onChange={(nameQuery) => onChange({ ...state, nameQuery })}
+      />
+
+      <MultiSelect
+        label="Sector"
+        options={SECTORS.map((s) => ({ value: s.tag, label: s.label }))}
+        selected={state.sectors}
+        onChange={(sectors) => onChange({ ...state, sectors })}
+      />
+
+      <MultiSelect
+        label="Stage"
+        options={STAGES.map((s) => ({ value: s, label: STAGE_LABELS[s] }))}
+        selected={state.stages}
+        onChange={(stages) => onChange({ ...state, stages })}
+      />
+
+      <MultiSelect
+        label="Country"
+        options={meta.countries.map((c) => ({ value: c, label: c }))}
+        selected={state.countries}
+        onChange={(countries) => onChange({ ...state, countries })}
+      />
+
+      <YearRange
+        meta={meta}
+        min={state.foundedMin}
+        max={state.foundedMax}
+        onChange={(foundedMin, foundedMax) =>
+          onChange({ ...state, foundedMin, foundedMax })
+        }
+      />
+
+      {isFilterActive(state) && (
+        <div className="ml-auto">
+          <ResetButton onClick={() => onChange(EMPTY_FILTERS)} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/companies/CompanyProfile.tsx
+++ b/web/src/components/companies/CompanyProfile.tsx
@@ -1,0 +1,189 @@
+import Link from "next/link";
+import { ArrowLeft, ExternalLink } from "lucide-react";
+
+import type { Company } from "@/lib/types";
+import { primarySectorHex, sectorLabel } from "@/lib/taxonomy";
+import {
+  formatHeadcount,
+  formatLatestFunding,
+  formatLocation,
+  formatStage,
+  formatUsd,
+} from "@/lib/format";
+
+interface Props {
+  company: Company;
+}
+
+export function CompanyProfile({ company }: Props) {
+  const accent = primarySectorHex(company.sector_tags);
+  const location = formatLocation(company);
+  const stage = formatStage(company.stage);
+  const latestFunding = formatLatestFunding(company.latest_funding_event);
+  const totalRaised = formatUsd(company.total_raised_usd);
+  const valuation = formatUsd(company.valuation_usd);
+  const headcount = formatHeadcount(company);
+
+  return (
+    <article className="mx-auto w-full max-w-[900px] px-5 py-10">
+      <Link
+        href="/companies"
+        className="inline-flex items-center gap-1.5 text-[12px] font-medium text-text-muted transition-colors hover:text-accent"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        All companies
+      </Link>
+
+      <div className="mt-6 overflow-hidden rounded-xl border border-border bg-surface">
+        <div className="h-1.5 w-full" style={{ background: accent }} aria-hidden />
+
+        <header className="border-b border-border px-6 py-6">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h1 className="text-3xl font-semibold tracking-tight text-text sm:text-4xl">
+                {company.name}
+              </h1>
+              {location && (
+                <p className="mt-1.5 text-[14px] text-text-muted">{location}</p>
+              )}
+            </div>
+            {company.website && (
+              <a
+                href={company.website}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md border border-border-strong bg-surface-2 px-3 py-1.5 text-[13px] font-medium text-text transition-colors hover:border-accent hover:text-accent"
+              >
+                Website
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+          </div>
+
+          <dl className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <Stat label="Stage" value={stage} />
+            <Stat label="Founded" value={company.founded_year !== null ? String(company.founded_year) : null} />
+            <Stat label="Total raised" value={totalRaised} highlight />
+            <Stat label="Valuation" value={valuation} highlight />
+            <Stat label="Headcount" value={headcount} />
+            <Stat label="Verified" value={company.profile_verified_at?.slice(0, 10) ?? null} />
+            {latestFunding && (
+              <div className="col-span-2">
+                <Label>Latest funding</Label>
+                <div className="mt-1 text-[14px] text-text">{latestFunding}</div>
+              </div>
+            )}
+          </dl>
+        </header>
+
+        <div className="grid grid-cols-1 gap-6 px-6 py-6 sm:grid-cols-3">
+          <section className="sm:col-span-2">
+            {company.summary && (
+              <>
+                <Label>Summary</Label>
+                <p className="mt-2 whitespace-pre-line text-[14px] leading-relaxed text-text">
+                  {company.summary}
+                </p>
+              </>
+            )}
+
+            {company.founders.length > 0 && (
+              <div className="mt-6">
+                <Label>Founders</Label>
+                <p className="mt-2 text-[14px] text-text">{company.founders.join(", ")}</p>
+              </div>
+            )}
+
+            {company.profile_sources.length > 0 && (
+              <div className="mt-6">
+                <Label>Sources</Label>
+                <ul className="mt-2 space-y-1">
+                  {company.profile_sources.map((src) => (
+                    <li key={src}>
+                      <a
+                        href={src}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[13px] text-text-muted transition-colors hover:text-accent"
+                      >
+                        {prettyHostname(src)}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+
+          <aside>
+            <Label>Sectors</Label>
+            <ul className="mt-2 space-y-1.5">
+              {company.sector_tags.map((tag) => (
+                <li key={tag} className="flex items-center gap-2 text-[13px] text-text">
+                  <span
+                    className="h-2 w-2 rounded-full"
+                    style={{ background: primarySectorHex([tag]) }}
+                    aria-hidden
+                  />
+                  {sectorLabel(tag)}
+                </li>
+              ))}
+            </ul>
+
+            {company.discovery_source && (
+              <div className="mt-6 rounded-md border border-border bg-bg/40 px-3 py-2 text-[12px] text-text-muted">
+                <Label>Discovery</Label>
+                <div className="mt-1 text-text">{company.discovery_source}</div>
+              </div>
+            )}
+          </aside>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  highlight = false,
+}: {
+  label: string;
+  value: string | null;
+  highlight?: boolean;
+}) {
+  if (!value) {
+    return (
+      <div>
+        <Label>{label}</Label>
+        <div className="mt-1 text-[14px] text-text-subtle">-</div>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <Label>{label}</Label>
+      <div
+        className={`mt-1 text-[14px] tabular-nums ${highlight ? "font-semibold text-accent" : "text-text"}`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-text-subtle">
+      {children}
+    </div>
+  );
+}
+
+function prettyHostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}

--- a/web/src/components/filters/primitives.tsx
+++ b/web/src/components/filters/primitives.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronDown, RotateCcw, Search } from "lucide-react";
+
+import { cn } from "@/lib/cn";
+import type { FilterMeta } from "@/lib/filters";
+
+export interface Option {
+  value: string;
+  label: string;
+}
+
+export function SearchInput({
+  value,
+  onChange,
+  placeholder = "Search by name...",
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <label className="flex min-w-[200px] flex-1 items-center gap-2 rounded-md border border-border bg-surface-2 px-2.5 py-1.5 focus-within:border-accent">
+      <Search className="h-3.5 w-3.5 text-text-subtle" />
+      <input
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full bg-transparent text-[13px] text-text outline-none placeholder:text-text-subtle"
+      />
+    </label>
+  );
+}
+
+export function MultiSelect({
+  label,
+  options,
+  selected,
+  onChange,
+}: {
+  label: string;
+  options: Option[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const esc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    document.addEventListener("keydown", esc);
+    return () => {
+      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("keydown", esc);
+    };
+  }, [open]);
+
+  const toggle = (value: string) => {
+    if (selected.includes(value)) {
+      onChange(selected.filter((s) => s !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  };
+
+  const summary =
+    selected.length === 0
+      ? label
+      : selected.length === 1
+        ? (options.find((o) => o.value === selected[0])?.label ?? selected[0])
+        : `${label}: ${selected.length}`;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((s) => !s)}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[13px] font-medium transition-colors",
+          selected.length > 0
+            ? "border-accent bg-accent-soft text-accent"
+            : "border-border bg-surface-2 text-text-muted hover:border-border-strong hover:text-text",
+        )}
+      >
+        {summary}
+        <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-180")} />
+      </button>
+
+      {open && options.length > 0 && (
+        <div className="aisw-scroll absolute left-0 top-full z-20 mt-1 max-h-[280px] w-[260px] overflow-y-auto rounded-md border border-border bg-surface shadow-2xl">
+          <ul role="listbox" aria-multiselectable="true" className="py-1">
+            {options.map((opt) => {
+              const checked = selected.includes(opt.value);
+              return (
+                <li key={opt.value}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={checked}
+                    onClick={() => toggle(opt.value)}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-[13px] transition-colors",
+                      checked
+                        ? "text-accent hover:bg-accent-soft"
+                        : "text-text hover:bg-surface-2",
+                    )}
+                  >
+                    <span className="truncate">{opt.label}</span>
+                    {checked && <Check className="h-3.5 w-3.5 shrink-0" />}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function YearRange({
+  meta,
+  min,
+  max,
+  onChange,
+}: {
+  meta: FilterMeta;
+  min: number | null;
+  max: number | null;
+  onChange: (min: number | null, max: number | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const esc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    document.addEventListener("keydown", esc);
+    return () => {
+      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("keydown", esc);
+    };
+  }, [open]);
+
+  const active = min !== null || max !== null;
+  const summary = active
+    ? `Founded: ${min ?? meta.foundedMin} - ${max ?? meta.foundedMax}`
+    : "Founded";
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((s) => !s)}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[13px] font-medium transition-colors",
+          active
+            ? "border-accent bg-accent-soft text-accent"
+            : "border-border bg-surface-2 text-text-muted hover:border-border-strong hover:text-text",
+        )}
+      >
+        {summary}
+        <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-180")} />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full z-20 mt-1 w-[260px] rounded-md border border-border bg-surface p-3 shadow-2xl">
+          <div className="grid grid-cols-2 gap-2">
+            <NumberField
+              label="From"
+              value={min ?? meta.foundedMin}
+              min={meta.foundedMin}
+              max={meta.foundedMax}
+              onChange={(v) => onChange(v, max)}
+            />
+            <NumberField
+              label="To"
+              value={max ?? meta.foundedMax}
+              min={meta.foundedMin}
+              max={meta.foundedMax}
+              onChange={(v) => onChange(min, v)}
+            />
+          </div>
+          {active && (
+            <button
+              type="button"
+              onClick={() => onChange(null, null)}
+              className="mt-2 inline-flex items-center gap-1 text-[12px] text-text-muted hover:text-accent"
+            >
+              <RotateCcw className="h-3 w-3" />
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (next: number | null) => void;
+}) {
+  return (
+    <label className="block">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-subtle">
+        {label}
+      </span>
+      <input
+        type="number"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          onChange(Number.isFinite(n) ? n : null);
+        }}
+        className="mt-1 w-full rounded-md border border-border bg-surface-2 px-2 py-1 text-[13px] text-text outline-none focus:border-accent"
+      />
+    </label>
+  );
+}
+
+export function ResetButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1 rounded-md border border-border-strong bg-surface-2 px-2.5 py-1.5 text-[12px] font-medium text-text-muted transition-colors hover:border-accent hover:text-accent"
+    >
+      <RotateCcw className="h-3 w-3" />
+      Reset
+    </button>
+  );
+}

--- a/web/src/components/map/FilterBar.tsx
+++ b/web/src/components/map/FilterBar.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { Check, ChevronDown, RotateCcw, Search } from "lucide-react";
-
-import { cn } from "@/lib/cn";
 import { SECTORS, STAGE_LABELS, STAGES } from "@/lib/taxonomy";
 import {
   EMPTY_FILTERS,
@@ -11,6 +7,12 @@ import {
   type FilterState,
   isFilterActive,
 } from "@/lib/filters";
+import {
+  MultiSelect,
+  ResetButton,
+  SearchInput,
+  YearRange,
+} from "@/components/filters/primitives";
 
 interface Props {
   state: FilterState;
@@ -63,252 +65,8 @@ export function FilterBar({ state, meta, onChange, visibleCount, totalCount }: P
           <span className="font-semibold text-text">{visibleCount}</span>
           <span> of {totalCount}</span>
         </span>
-        {isFilterActive(state) && (
-          <button
-            type="button"
-            onClick={() => onChange(EMPTY_FILTERS)}
-            className="inline-flex items-center gap-1 rounded-md border border-border-strong bg-surface-2 px-2.5 py-1.5 text-[12px] font-medium text-text-muted transition-colors hover:border-accent hover:text-accent"
-          >
-            <RotateCcw className="h-3 w-3" />
-            Reset
-          </button>
-        )}
+        {isFilterActive(state) && <ResetButton onClick={() => onChange(EMPTY_FILTERS)} />}
       </div>
     </div>
-  );
-}
-
-function SearchInput({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (next: string) => void;
-}) {
-  return (
-    <label className="flex min-w-[200px] flex-1 items-center gap-2 rounded-md border border-border bg-surface-2 px-2.5 py-1.5 focus-within:border-accent">
-      <Search className="h-3.5 w-3.5 text-text-subtle" />
-      <input
-        type="search"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="Search by name..."
-        className="w-full bg-transparent text-[13px] text-text outline-none placeholder:text-text-subtle"
-      />
-    </label>
-  );
-}
-
-interface Option {
-  value: string;
-  label: string;
-}
-
-function MultiSelect({
-  label,
-  options,
-  selected,
-  onChange,
-}: {
-  label: string;
-  options: Option[];
-  selected: string[];
-  onChange: (next: string[]) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (!ref.current?.contains(e.target as Node)) setOpen(false);
-    };
-    const esc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    document.addEventListener("keydown", esc);
-    return () => {
-      document.removeEventListener("mousedown", handler);
-      document.removeEventListener("keydown", esc);
-    };
-  }, [open]);
-
-  const toggle = (value: string) => {
-    if (selected.includes(value)) {
-      onChange(selected.filter((s) => s !== value));
-    } else {
-      onChange([...selected, value]);
-    }
-  };
-
-  const summary =
-    selected.length === 0
-      ? label
-      : selected.length === 1
-        ? (options.find((o) => o.value === selected[0])?.label ?? selected[0])
-        : `${label}: ${selected.length}`;
-
-  return (
-    <div className="relative" ref={ref}>
-      <button
-        type="button"
-        onClick={() => setOpen((s) => !s)}
-        className={cn(
-          "inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[13px] font-medium transition-colors",
-          selected.length > 0
-            ? "border-accent bg-accent-soft text-accent"
-            : "border-border bg-surface-2 text-text-muted hover:border-border-strong hover:text-text",
-        )}
-      >
-        {summary}
-        <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-180")} />
-      </button>
-
-      {open && options.length > 0 && (
-        <div className="aisw-scroll absolute left-0 top-full z-20 mt-1 max-h-[280px] w-[260px] overflow-y-auto rounded-md border border-border bg-surface shadow-2xl">
-          <ul role="listbox" aria-multiselectable="true" className="py-1">
-            {options.map((opt) => {
-              const checked = selected.includes(opt.value);
-              return (
-                <li key={opt.value}>
-                  <button
-                    type="button"
-                    role="option"
-                    aria-selected={checked}
-                    onClick={() => toggle(opt.value)}
-                    className={cn(
-                      "flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-[13px] transition-colors",
-                      checked
-                        ? "text-accent hover:bg-accent-soft"
-                        : "text-text hover:bg-surface-2",
-                    )}
-                  >
-                    <span className="truncate">{opt.label}</span>
-                    {checked && <Check className="h-3.5 w-3.5 shrink-0" />}
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function YearRange({
-  meta,
-  min,
-  max,
-  onChange,
-}: {
-  meta: FilterMeta;
-  min: number | null;
-  max: number | null;
-  onChange: (min: number | null, max: number | null) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (!ref.current?.contains(e.target as Node)) setOpen(false);
-    };
-    const esc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    document.addEventListener("keydown", esc);
-    return () => {
-      document.removeEventListener("mousedown", handler);
-      document.removeEventListener("keydown", esc);
-    };
-  }, [open]);
-
-  const active = min !== null || max !== null;
-  const summary = active ? `Founded: ${min ?? meta.foundedMin} - ${max ?? meta.foundedMax}` : "Founded";
-
-  return (
-    <div className="relative" ref={ref}>
-      <button
-        type="button"
-        onClick={() => setOpen((s) => !s)}
-        className={cn(
-          "inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[13px] font-medium transition-colors",
-          active
-            ? "border-accent bg-accent-soft text-accent"
-            : "border-border bg-surface-2 text-text-muted hover:border-border-strong hover:text-text",
-        )}
-      >
-        {summary}
-        <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-180")} />
-      </button>
-
-      {open && (
-        <div className="absolute left-0 top-full z-20 mt-1 w-[260px] rounded-md border border-border bg-surface p-3 shadow-2xl">
-          <div className="grid grid-cols-2 gap-2">
-            <NumberField
-              label="From"
-              value={min ?? meta.foundedMin}
-              min={meta.foundedMin}
-              max={meta.foundedMax}
-              onChange={(v) => onChange(v, max)}
-            />
-            <NumberField
-              label="To"
-              value={max ?? meta.foundedMax}
-              min={meta.foundedMin}
-              max={meta.foundedMax}
-              onChange={(v) => onChange(min, v)}
-            />
-          </div>
-          {active && (
-            <button
-              type="button"
-              onClick={() => onChange(null, null)}
-              className="mt-2 inline-flex items-center gap-1 text-[12px] text-text-muted hover:text-accent"
-            >
-              <RotateCcw className="h-3 w-3" />
-              Clear
-            </button>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function NumberField({
-  label,
-  value,
-  min,
-  max,
-  onChange,
-}: {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  onChange: (next: number | null) => void;
-}) {
-  return (
-    <label className="block">
-      <span className="text-[10px] font-semibold uppercase tracking-[0.12em] text-text-subtle">
-        {label}
-      </span>
-      <input
-        type="number"
-        min={min}
-        max={max}
-        value={value}
-        onChange={(e) => {
-          const n = Number(e.target.value);
-          onChange(Number.isFinite(n) ? n : null);
-        }}
-        className="mt-1 w-full rounded-md border border-border bg-surface-2 px-2 py-1 text-[13px] text-text outline-none focus:border-accent"
-      />
-    </label>
   );
 }

--- a/web/src/lib/companies-server.ts
+++ b/web/src/lib/companies-server.ts
@@ -1,0 +1,108 @@
+// Server-side helpers for fetching companies directly from Supabase.
+// Mirrors SupabaseSource.list_companies in src/ai_sector_watch/storage/data_source.py.
+
+import "server-only";
+
+import { sql } from "./db";
+import type { Company, FundingEvent } from "./types";
+
+type Row = Record<string, unknown>;
+
+function toNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function toIsoDate(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") return value;
+  return null;
+}
+
+function toStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((v) => String(v));
+  return [];
+}
+
+function buildFunding(row: Row): FundingEvent | null {
+  if (!row.latest_funding_id) return null;
+  return {
+    id: String(row.latest_funding_id),
+    announced_on: toIsoDate(row.latest_funding_announced_on),
+    stage: (row.latest_funding_stage as string | null) ?? null,
+    amount_usd: toNumber(row.latest_funding_amount_usd),
+    currency_raw: (row.latest_funding_currency_raw as string | null) ?? null,
+    lead_investor: (row.latest_funding_lead_investor as string | null) ?? null,
+    investors: toStringArray(row.latest_funding_investors),
+    source_url: (row.latest_funding_source_url as string | null) ?? null,
+  };
+}
+
+function buildCompany(row: Row): Company {
+  return {
+    id: String(row.id),
+    name: row.name as string,
+    country: (row.country as string | null) ?? null,
+    city: (row.city as string | null) ?? null,
+    lat: toNumber(row.lat),
+    lon: toNumber(row.lon),
+    website: (row.website as string | null) ?? null,
+    sector_tags: toStringArray(row.sector_tags),
+    stage: (row.stage as string | null) ?? null,
+    founded_year: toNumber(row.founded_year),
+    summary: (row.summary as string | null) ?? null,
+    discovery_status: row.discovery_status as string,
+    discovery_source: (row.discovery_source as string | null) ?? null,
+    founders: toStringArray(row.founders),
+    total_raised_usd: toNumber(row.total_raised_usd),
+    total_raised_currency_raw: (row.total_raised_currency_raw as string | null) ?? null,
+    total_raised_as_of: toIsoDate(row.total_raised_as_of),
+    total_raised_source_url: (row.total_raised_source_url as string | null) ?? null,
+    valuation_usd: toNumber(row.valuation_usd),
+    valuation_currency_raw: (row.valuation_currency_raw as string | null) ?? null,
+    valuation_as_of: toIsoDate(row.valuation_as_of),
+    valuation_source_url: (row.valuation_source_url as string | null) ?? null,
+    headcount_estimate: toNumber(row.headcount_estimate),
+    headcount_min: toNumber(row.headcount_min),
+    headcount_max: toNumber(row.headcount_max),
+    headcount_as_of: toIsoDate(row.headcount_as_of),
+    headcount_source_url: (row.headcount_source_url as string | null) ?? null,
+    profile_confidence: toNumber(row.profile_confidence),
+    profile_sources: toStringArray(row.profile_sources),
+    profile_verified_at: toIsoDate(row.profile_verified_at),
+    latest_funding_event: buildFunding(row),
+  };
+}
+
+export async function listVerifiedCompanies(): Promise<Company[]> {
+  const rows = await sql<Row[]>`
+    SELECT
+        c.*,
+        fe.id AS latest_funding_id,
+        fe.announced_on AS latest_funding_announced_on,
+        fe.stage AS latest_funding_stage,
+        fe.amount_usd AS latest_funding_amount_usd,
+        fe.currency_raw AS latest_funding_currency_raw,
+        fe.lead_investor AS latest_funding_lead_investor,
+        fe.investors AS latest_funding_investors,
+        fe.source_url AS latest_funding_source_url
+    FROM companies c
+    LEFT JOIN LATERAL (
+        SELECT id, announced_on, stage, amount_usd, currency_raw,
+               lead_investor, investors, source_url, created_at
+        FROM funding_events
+        WHERE company_id = c.id
+        ORDER BY announced_on DESC NULLS LAST, created_at DESC
+        LIMIT 1
+    ) fe ON TRUE
+    WHERE c.discovery_status = 'verified'
+    ORDER BY c.name
+  `;
+  return rows.map(buildCompany);
+}

--- a/web/src/lib/db.ts
+++ b/web/src/lib/db.ts
@@ -1,18 +1,23 @@
-// Singleton postgres-js client. Server-only — never import this from a client component.
+// Lazy postgres-js client. Server-only — never import this from a client component.
 //
 // Reads SUPABASE_DB_URL, the same env var the Python pipeline and Streamlit dashboard
 // use (see src/ai_sector_watch/storage/supabase_db.py). The value is supplied via
 // `op run --env-file=.env.local --` per the repo conventions.
+//
+// The client is created on first query, not at module load, so `next build`
+// doesn't fail when collecting page data without env access.
 
 import "server-only";
 
 import postgres from "postgres";
 
+type Sql = ReturnType<typeof postgres>;
+
 declare global {
-  var __aisw_sql__: ReturnType<typeof postgres> | undefined;
+  var __aisw_sql__: Sql | undefined;
 }
 
-function makeClient() {
+function makeClient(): Sql {
   const url = process.env.SUPABASE_DB_URL;
   if (!url) {
     throw new Error(
@@ -28,8 +33,25 @@ function makeClient() {
   });
 }
 
-export const sql = globalThis.__aisw_sql__ ?? makeClient();
-
-if (process.env.NODE_ENV !== "production") {
-  globalThis.__aisw_sql__ = sql;
+function getSql(): Sql {
+  if (!globalThis.__aisw_sql__) {
+    globalThis.__aisw_sql__ = makeClient();
+  }
+  return globalThis.__aisw_sql__;
 }
+
+// Proxy that defers client creation to the first query. Target is a function
+// so the proxy itself is callable (postgres-js uses sql as a tagged template).
+const proxyTarget = function () {} as unknown as Sql;
+export const sql = new Proxy(proxyTarget, {
+  get(_target, prop) {
+    const client = getSql() as unknown as Record<string | symbol, unknown>;
+    const value = client[prop];
+    return typeof value === "function"
+      ? (value as (...args: unknown[]) => unknown).bind(client)
+      : value;
+  },
+  apply(_target, _this, args) {
+    return (getSql() as unknown as (...a: unknown[]) => unknown)(...args);
+  },
+}) as Sql;

--- a/web/src/lib/slug.ts
+++ b/web/src/lib/slug.ts
@@ -1,0 +1,45 @@
+// Stable, collision-tolerant slug helper. For 52 companies, name-based slugs
+// are unique in practice; if a real collision shows up, we fall back to
+// the company id suffix.
+
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+export function buildSlugMap<T extends { id: string; name: string }>(
+  items: T[],
+): Map<string, T> {
+  const map = new Map<string, T>();
+  for (const item of items) {
+    const base = slugify(item.name);
+    if (!map.has(base)) {
+      map.set(base, item);
+      continue;
+    }
+    // Collision: append last 6 chars of id for stability.
+    const tail = item.id.replace(/-/g, "").slice(-6);
+    map.set(`${base}-${tail}`, item);
+  }
+  return map;
+}
+
+export function findBySlug<T extends { id: string; name: string }>(
+  items: T[],
+  slug: string,
+): T | undefined {
+  return buildSlugMap(items).get(slug);
+}
+
+export function slugFor(item: { id: string; name: string }, all: { id: string; name: string }[]): string {
+  // Reverse lookup: find the slug that maps back to this item.
+  const map = buildSlugMap(all);
+  for (const [s, candidate] of map.entries()) {
+    if (candidate.id === item.id) return s;
+  }
+  return slugify(item.name);
+}


### PR DESCRIPTION
## Summary

Replace the `/companies` stub with a full directory + detail pages (Phase 2A of the Streamlit replacement).

## Why

Phase 1 (#62 / PR #63) shipped a high-fidelity prototype with a polished `/map` and stub pages elsewhere. This issue gives `/companies` the same treatment: a real directory backed by live Supabase data, with sortable/filterable views and per-company detail pages. Visitors can now browse, search, and dive into individual profiles, completing the natural "map -> companies -> profile" flow.

## Stack-change note

No stack change. Builds on PR #63's `web/` Next.js app. Live Streamlit dashboard at aimap.cliftonfamily.co is untouched.

## Branch base

This branch is rebased on top of `claude-code/62-feature-spike-a-next-js-maplibre-dashboa` (PR #63) since `web/` only exists there. After #63 merges, this rebases cleanly onto `main`. Reviewer should merge #63 first.

## Changes

- `refactor(web)`: extract MultiSelect / YearRange / SearchInput / ResetButton from `map/FilterBar.tsx` into `components/filters/primitives.tsx`. The map filter bar now imports these. No behaviour change.
- `fix(web)`: `lib/db.ts` is now a lazy Proxy so `next build` no longer requires `SUPABASE_DB_URL` at module load. Important for CI builds without DB access.
- `feat(web)`:
  - `/companies` directory: sortable table on lg+, 2-column card grid on sm+, single-column on mobile. Columns: name + sector accent + website link, stage, founded, total raised, headcount, sectors (first 2 + overflow count), location. Sort by name / founded / raised / headcount with asc/desc toggle. Filter parity with `/map` (sectors, stages, countries, founded year range, name search). Sort key + direction live in URL search params alongside filter state, so deep links restore everything.
  - `/companies/[slug]` dynamic route: server-rendered profile with stats grid (stage, founded, raised, valuation, headcount, verified date), summary, founders, sectors with accent dots, source links, discovery source. Back link to `/companies`.
  - `lib/companies-server.ts` shared between the API route and the slug page; mirrors `SupabaseSource.list_companies` SQL.
  - `lib/slug.ts`: `slugify`, `buildSlugMap`, `findBySlug`, `slugFor`. Stable id-tail fallback for unlikely collisions.

## Test plan

- [ ] `pytest -q` passes (no Python touched)
- [ ] `ruff check .` passes
- [ ] `black --check .` passes
- [x] `cd web && npm run build` passes (verified locally — 9 routes generated, /companies and /companies/[slug] included)
- [x] `cd web && npm run lint` passes (verified locally — 0 errors, 0 warnings)
- [x] Manual smoke check via Claude Preview at 1400x900:
  - `/companies` table renders all 52 verified companies with sector accent dots, sortable columns
  - Same page at 981x917 renders the 2-column card grid (lg breakpoint trigger)
  - `/companies/atlassian` renders the polished detail layout with stats grid, summary, sector chips, sources
  - "All companies" back link returns to the directory
- [ ] `PROJECT_PROGRESS.md` updated *if* milestone — n/a, not yet (cutover #68 is the milestone)

## Multi-agent coordination

- [x] Followed [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md) pre-flight
- [x] Self-assigned to #64
- [x] Branch `claude-code/64-feature-phase-2a-companies-directory-wit`
- [x] Rebased onto #63's branch (cannot rebase to main yet because web/ is on #63)

## Screenshots

Verified locally:
- `/companies` table at 1400px wide showing all 52 companies, sector accent dots, sortable columns
- `/companies` cards at 981px showing 2-column grid with sector chips
- `/companies/atlassian` showing the full profile with stats grid and summary

To reproduce:
```bash
cd web
op run --account my.1password.com --env-file=.env.local -- npm run dev
# http://localhost:3000/companies
```

## Related issues

Closes #64
Sibling issues: #65 (News), #66 (Admin), #67 (Polish + About)
Followed by: #68 (Azure cutover)
Tracker: #61
