### PR TITLE
[#67] Phase 2D: About, a11y, polish

### DIFF
--- a/web/public/architecture.svg
+++ b/web/public/architecture.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1120 500">
+  <title id="title">AI Sector Watch architecture</title>
+  <desc id="desc">GitHub Actions fetches public sources, runs the weekly pipeline, writes to Supabase, and the Streamlit dashboard reads verified records.</desc>
+  <defs>
+    <style>
+      .bg { fill: #0B0F14; }
+      .box { fill: #121821; stroke: #2C384D; stroke-width: 1.5; rx: 8; }
+      .source { fill: #1B2230; stroke: #2C384D; stroke-width: 1.5; rx: 8; }
+      .title { fill: #E6EDF3; font: 600 20px Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .body { fill: #8B95A6; font: 400 15px Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .small { fill: #8B95A6; font: 500 13px Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: 0.06em; }
+      .accent { fill: #F4B740; }
+      .line { fill: none; stroke: #F4B740; stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrow); }
+      .read { fill: none; stroke: #8B95A6; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrow-muted); }
+    </style>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="7.5" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L8,3 z" fill="#F4B740" />
+    </marker>
+    <marker id="arrow-muted" markerWidth="10" markerHeight="10" refX="7.5" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L8,3 z" fill="#8B95A6" />
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1120" height="500" rx="8" />
+
+  <rect class="box" x="420" y="24" width="280" height="82" />
+  <text class="title" x="560" y="60" text-anchor="middle">GitHub Actions cron</text>
+  <text class="body" x="560" y="84" text-anchor="middle">Sunday 18:00 UTC</text>
+
+  <rect class="source" x="48" y="178" width="230" height="112" />
+  <text class="title" x="163" y="218" text-anchor="middle">Public sources</text>
+  <text class="body" x="163" y="246" text-anchor="middle">RSS, arXiv, Hugging Face</text>
+  <text class="body" x="163" y="270" text-anchor="middle">and startup news</text>
+
+  <rect class="box" x="356" y="148" width="408" height="174" />
+  <text class="title" x="560" y="186" text-anchor="middle">weekly_pipeline.py</text>
+  <text class="body" x="398" y="222">1. fetch every source</text>
+  <text class="body" x="398" y="248">2. LLM extracts company mentions</text>
+  <text class="body" x="398" y="274">3. validate, classify, and geocode</text>
+  <text class="body" x="398" y="300">4. upsert pending records, news, and digest</text>
+
+  <rect class="box" x="420" y="378" width="280" height="82" />
+  <text class="title" x="560" y="414" text-anchor="middle">Supabase Postgres</text>
+  <text class="body" x="560" y="438" text-anchor="middle">companies, news, funding, ingest</text>
+
+  <rect class="box" x="812" y="378" width="260" height="82" />
+  <text class="title" x="942" y="414" text-anchor="middle">Streamlit dashboard</text>
+  <text class="body" x="942" y="438" text-anchor="middle">Azure App Service</text>
+
+  <path class="line" d="M560 106 V142" />
+  <path class="line" d="M278 234 H348" />
+  <path class="line" d="M560 322 V370" />
+  <path class="read" d="M700 419 H804" />
+  <text class="small" x="752" y="404" text-anchor="middle">READ</text>
+
+  <circle class="accent" cx="560" cy="146" r="4" />
+  <circle class="accent" cx="352" cy="234" r="4" />
+  <circle class="accent" cx="560" cy="374" r="4" />
+</svg>

--- a/web/src/app/about/page.tsx
+++ b/web/src/app/about/page.tsx
@@ -1,17 +1,138 @@
 import type { Metadata } from "next";
-
-import { StubPage } from "@/components/StubPage";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowUpRight, Github, Linkedin, MessageCircle } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "About",
+  description:
+    "Methodology, scope, data quality, and source code for AI Sector Watch.",
 };
+
+const GITHUB_URL = "https://github.com/SCClifton/ai-sector-watch";
+const ISSUES_URL = `${GITHUB_URL}/issues`;
+const LINKEDIN_URL = "https://www.linkedin.com/in/sam-c-clifton/";
 
 export default function AboutPage() {
   return (
-    <StubPage
-      eyebrow="Methodology"
-      title="About"
-      body="How AI Sector Watch is built: the agent pipeline, the source list, the sector taxonomy, and the people behind it. Stub for now: the prototype focuses on the map page first."
-    />
+    <article className="mx-auto w-full max-w-[900px] px-5 py-12">
+      <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-text-subtle">
+        Methodology
+      </div>
+      <h1 className="mt-2 text-4xl font-semibold tracking-tight text-text sm:text-5xl">
+        About
+      </h1>
+      <p className="mt-3 text-[14px] text-text-muted">
+        Methodology, scope, data quality, and source code.
+      </p>
+
+      <Section title="What this is">
+        <p>
+          AI Sector Watch is a public map of the Australian and New Zealand AI startup
+          landscape. It combines a verified company index with a weekly agent pipeline that
+          scans public sources for new activity.
+        </p>
+      </Section>
+
+      <Section title="What is tracked">
+        <div className="grid grid-cols-3 gap-3">
+          <Stat label="Scope" value="AU + NZ" />
+          <Stat label="Sectors" value="21" />
+          <Stat label="Cadence" value="Weekly" />
+        </div>
+        <p className="mt-5">
+          The index tracks AI-native and AI-enabled companies across the fixed taxonomy
+          documented in the repository. Inputs include startup news, RSS feeds, arXiv,
+          Hugging Face papers, and related public signals.
+        </p>
+      </Section>
+
+      <Section title="How discovery works">
+        <p>
+          A scheduled GitHub Actions job fetches each source, then an LLM extracts company
+          mentions from every item. New ANZ candidates are validated, classified against the
+          sector taxonomy, geocoded with a static city table, and written to Supabase as
+          pending review. The public dashboard reads only verified companies.
+        </p>
+        <div className="mt-5 overflow-hidden rounded-xl border border-border bg-surface/50 p-4">
+          <Image
+            src="/architecture.svg"
+            alt="AI Sector Watch architecture: GitHub Actions cron triggers the weekly pipeline, which fetches public sources, runs LLM extraction, validates and classifies candidates, geocodes them against the ANZ city table, and upserts to Supabase Postgres. The dashboard reads verified records."
+            width={1120}
+            height={500}
+            className="w-full"
+            unoptimized
+          />
+        </div>
+      </Section>
+
+      <Section title="Data quality and disclaimers">
+        <p>
+          The data is auto-extracted from public sources and manually reviewed before
+          publication. It can still contain errors, omissions, stale links, or imperfect
+          sector tags. For corrections, open an issue in the project tracker.
+        </p>
+        <div className="mt-4">
+          <Link
+            href={ISSUES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md border border-border-strong bg-surface px-3.5 py-2 text-[13px] font-medium text-text transition-colors hover:border-accent hover:text-accent"
+          >
+            <MessageCircle className="h-3.5 w-3.5" />
+            Report a correction
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </Link>
+        </div>
+      </Section>
+
+      <Section title="Built by">
+        <p>
+          Built by Sam Clifton as an open research and engineering project. The repository
+          is the primary record: source code, workflow files, schema, taxonomy, and
+          operating notes are all public.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-2">
+          <Link
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md bg-accent px-4 py-2 text-[13px] font-semibold text-bg transition-colors hover:bg-accent-hover"
+          >
+            <Github className="h-3.5 w-3.5" />
+            GitHub repository
+          </Link>
+          <Link
+            href={LINKEDIN_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md border border-border-strong bg-surface px-4 py-2 text-[13px] font-medium text-text transition-colors hover:border-accent hover:text-accent"
+          >
+            <Linkedin className="h-3.5 w-3.5" />
+            LinkedIn
+          </Link>
+        </div>
+      </Section>
+    </article>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-10">
+      <h2 className="text-lg font-semibold tracking-tight text-text">{title}</h2>
+      <div className="mt-3 text-[14px] leading-relaxed text-text-muted">{children}</div>
+    </section>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-surface p-3">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-text-subtle">
+        {label}
+      </div>
+      <div className="mt-1 text-[18px] font-semibold tabular-nums text-text">{value}</div>
+    </div>
   );
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -59,6 +59,43 @@ body {
   color: var(--aisw-accent-hover);
 }
 
+/* Accessible focus rings for keyboard users. */
+:focus-visible {
+  outline: 2px solid var(--aisw-accent);
+  outline-offset: 2px;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[role="option"]:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--aisw-accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Skip-link for keyboard users. Hidden until focused. */
+.aisw-skip-link {
+  position: absolute;
+  top: -100px;
+  left: 12px;
+  z-index: 100;
+  padding: 8px 14px;
+  background: var(--aisw-surface);
+  color: var(--aisw-accent);
+  border: 1px solid var(--aisw-accent);
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  transition: top 120ms ease;
+}
+.aisw-skip-link:focus {
+  top: 12px;
+}
+
 /* MapLibre dark-theme overrides */
 .maplibregl-map {
   font-family: var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -56,8 +56,13 @@ export default function RootLayout({
       className={`${inter.variable} ${jetbrainsMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-bg text-text">
+        <a href="#main-content" className="aisw-skip-link">
+          Skip to main content
+        </a>
         <Header />
-        <main className="flex-1 flex flex-col">{children}</main>
+        <main id="main-content" className="flex-1 flex flex-col">
+          {children}
+        </main>
         <Footer />
       </body>
     </html>

--- a/web/src/app/map/page.tsx
+++ b/web/src/app/map/page.tsx
@@ -110,6 +110,20 @@ function MapView() {
             No verified companies returned.
           </div>
         )}
+        {!error &&
+          companies !== null &&
+          companies.length > 0 &&
+          filtered.length === 0 && (
+            <div className="pointer-events-none absolute inset-0 grid place-items-center">
+              <div className="pointer-events-auto rounded-xl border border-border bg-surface/95 px-5 py-4 text-center shadow-2xl backdrop-blur-md">
+                <div className="text-[13px] font-semibold text-text">No companies match</div>
+                <p className="mt-1 max-w-[260px] text-[12px] text-text-muted">
+                  Try clearing a filter, or hit Reset to see all {companies.length} verified
+                  companies.
+                </p>
+              </div>
+            </div>
+          )}
 
         <CompanyDetail company={selected} onClose={() => setSelectedId(null)} />
       </div>

--- a/web/src/components/home/Constellation.tsx
+++ b/web/src/components/home/Constellation.tsx
@@ -148,40 +148,46 @@ export function Constellation({ companies }: Props) {
                   }}
                 />
 
-                {/* Label appears on hover */}
-                {isHover && (
-                  <g pointerEvents="none">
-                    <rect
-                      x={scaled + 10}
-                      y={-18}
-                      width={labelWidth(city.label, count)}
-                      height={36}
-                      rx={6}
-                      fill="rgba(18,24,33,0.96)"
-                      stroke="rgba(244,183,64,0.45)"
-                      strokeWidth={0.8}
-                    />
-                    <text
-                      x={scaled + 20}
-                      y={-2}
-                      fill="#E6EDF3"
-                      fontSize={11}
-                      fontWeight={600}
-                      style={{ letterSpacing: "0.01em" }}
-                    >
-                      {city.label}
-                    </text>
-                    <text
-                      x={scaled + 20}
-                      y={13}
-                      fill="rgba(244,183,64,0.95)"
-                      fontSize={10}
-                      fontWeight={500}
-                    >
-                      {count} {count === 1 ? "company" : "companies"}
-                    </text>
-                  </g>
-                )}
+                {/* Label appears on hover. Flips left when near the right edge. */}
+                {isHover && (() => {
+                  const lw = labelWidth(city.label, count);
+                  const flipLeft = city.x + scaled + 10 + lw > 800 - 12;
+                  const labelX = flipLeft ? -(scaled + 10 + lw) : scaled + 10;
+                  const textX = labelX + 10;
+                  return (
+                    <g pointerEvents="none">
+                      <rect
+                        x={labelX}
+                        y={-18}
+                        width={lw}
+                        height={36}
+                        rx={6}
+                        fill="rgba(18,24,33,0.96)"
+                        stroke="rgba(244,183,64,0.45)"
+                        strokeWidth={0.8}
+                      />
+                      <text
+                        x={textX}
+                        y={-2}
+                        fill="#E6EDF3"
+                        fontSize={11}
+                        fontWeight={600}
+                        style={{ letterSpacing: "0.01em" }}
+                      >
+                        {city.label}
+                      </text>
+                      <text
+                        x={textX}
+                        y={13}
+                        fill="rgba(244,183,64,0.95)"
+                        fontSize={10}
+                        fontWeight={500}
+                      >
+                        {count} {count === 1 ? "company" : "companies"}
+                      </text>
+                    </g>
+                  );
+                })()}
               </g>
             );
           })}


### PR DESCRIPTION
## Summary

Polish pass: ports the `/about` page from Streamlit, adds a11y essentials (focus rings, skip link), and fixes the constellation hover-label overflow + map empty state. (Phase 2D of the Streamlit replacement.)

## Why

Phases 2A through 2C deliver feature parity. This issue closes the polish gap so the new web/ app is a credible cutover candidate — accessible, documented, and free of small UX nits.

## Stack-change note

No stack change. Builds on PR #69 (#64) and PR #63 (#62). Live Streamlit dashboard at aimap.cliftonfamily.co is untouched.

## Branch base

Rebased on top of `claude-code/64-feature-phase-2a-companies-directory-wit` (PR #69). After #63 and #69 merge, this rebases cleanly onto main. Reviewer should merge #63 first, then #69, then this.

## Changes

- `feat(web)`: `/about` page replaces the stub. Ports content from `dashboard/pages/0_About.py`: what this is, what is tracked (3 stat cards), how discovery works (with the architecture SVG copied to `web/public/architecture.svg`), data quality + disclaimers (with a "Report a correction" link to issues), built by Sam (with GitHub + LinkedIn buttons).
- `feat(web)`: a11y essentials. Global `:focus-visible` ring using the accent token across every interactive element. Skip link at the top of `<body>` that jumps to `#main-content` (hidden until focused). `<main>` tagged with the matching id.
- `feat(web)`: `/map` empty state. When filters narrow to zero matches, shows a centred "No companies match" card with a hint to use Reset, instead of an empty map.
- `feat(web)`: constellation hover-label flip. Auckland, Wellington, Christchurch, and Brisbane labels now render to the left of the dot when they would overflow the right edge of the 800px viewBox. No layout shift on hover.

## Test plan

- [ ] `pytest -q` passes (no Python touched)
- [ ] `ruff check .` passes
- [ ] `black --check .` passes
- [x] `cd web && npm run build` passes (8 routes generated; /about now real, not a stub)
- [x] `cd web && npm run lint` passes (0 errors, 0 warnings)
- [x] Manual smoke check via Claude Preview at 1280x900:
  - `/about` renders the methodology + stats grid + architecture SVG + GitHub/LinkedIn buttons; active "About" nav link highlighted
  - `/map?sectors=foundation_models` then narrowing to zero matches shows the empty state
  - Hover the constellation Auckland dot — label appears to the left of the dot, fully visible
  - Tab through nav: skip link appears at top-left, focus rings visible on every element
- [ ] `PROJECT_PROGRESS.md` updated *if* milestone — n/a, not yet (cutover #68 is the milestone)

## Multi-agent coordination

- [x] Followed [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md) pre-flight
- [x] Self-assigned to #67
- [x] Branch `claude-code/67-feature-phase-2d-about-page-accessibilit`
- [x] Rebased onto #64's branch tip (cannot rebase to main yet because web/ is on #62 / #64)

## Out of scope (deferred)

- Full Lighthouse pass (axe-core integration). Manual a11y improvements landed; full audit is a follow-up.
- Mobile-specific layout tweaks beyond what's already responsive (companies cards, filter bar wrapping).
- Reduced-motion final sweep (already gated on the constellation; full audit deferred).

## Related issues

Closes #67
Sibling issues: #64 (Companies, PR #69), #65 (News), #66 (Admin)
Followed by: #68 (Azure cutover)
Tracker: #61
