### PR TITLE
[#65] Phase 2B: News feed and pipeline cost summary

### DIFF
--- a/web/src/app/api/news/route.ts
+++ b/web/src/app/api/news/route.ts
@@ -1,0 +1,25 @@
+// GET /api/news?limit=100 — recent news items.
+
+import { NextResponse } from "next/server";
+
+import { listRecentNews } from "@/lib/news-server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const limitParam = Number(url.searchParams.get("limit") ?? 100);
+  const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 500) : 100;
+
+  try {
+    const items = await listRecentNews(limit);
+    return NextResponse.json({ items });
+  } catch (err) {
+    console.error("GET /api/news failed", err);
+    return NextResponse.json(
+      { error: "failed to load news", detail: String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/spend-summary/route.ts
+++ b/web/src/app/api/spend-summary/route.ts
@@ -1,0 +1,21 @@
+// GET /api/spend-summary — last 4 weeks of weekly_run LLM cost.
+
+import { NextResponse } from "next/server";
+
+import { getSpendSummary } from "@/lib/news-server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  try {
+    const summary = await getSpendSummary();
+    return NextResponse.json({ summary });
+  } catch (err) {
+    console.error("GET /api/spend-summary failed", err);
+    return NextResponse.json(
+      { error: "failed to load spend summary", detail: String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/news/page.tsx
+++ b/web/src/app/news/page.tsx
@@ -1,17 +1,13 @@
 import type { Metadata } from "next";
 
-import { StubPage } from "@/components/StubPage";
+import { NewsContent } from "@/components/news/NewsContent";
 
 export const metadata: Metadata = {
   title: "News",
+  description:
+    "Chronological feed of relevant ANZ AI news linked to companies, plus pipeline cost.",
 };
 
 export default function NewsPage() {
-  return (
-    <StubPage
-      eyebrow="Pipeline"
-      title="News & weekly digest"
-      body="The most recent items the pipeline has ingested, plus the weekly markdown digest of what changed. Stub for now: the prototype focuses on the map page first."
-    />
-  );
+  return <NewsContent />;
 }

--- a/web/src/components/news/NewsContent.tsx
+++ b/web/src/components/news/NewsContent.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { ExternalLink, Sparkles } from "lucide-react";
+
+import type { Company, NewsItem } from "@/lib/types";
+import { slugFor } from "@/lib/slug";
+
+interface SpendSummary {
+  total_usd: number;
+  average_usd: number;
+  run_count: number;
+}
+
+export function NewsContent() {
+  const [items, setItems] = useState<NewsItem[] | null>(null);
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [spend, setSpend] = useState<SpendSummary | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      fetch("/api/news?limit=100").then((r) => r.json()),
+      fetch("/api/companies").then((r) => r.json()),
+      fetch("/api/spend-summary").then((r) => r.json()),
+    ])
+      .then(([news, companiesRes, spendRes]) => {
+        if (cancelled) return;
+        setItems(news.items ?? []);
+        setCompanies(companiesRes.companies ?? []);
+        setSpend(spendRes.summary ?? null);
+      })
+      .catch((err) => {
+        if (!cancelled) setLoadError(String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const companyById = useMemo(
+    () => new Map(companies.map((c) => [c.id, c])),
+    [companies],
+  );
+
+  return (
+    <section className="mx-auto w-full max-w-[900px] px-5 py-10">
+      <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-text-subtle">
+        Pipeline
+      </div>
+      <h1 className="mt-1 text-3xl font-semibold tracking-tight text-text sm:text-4xl">
+        News
+      </h1>
+      <p className="mt-2 max-w-2xl text-[14px] text-text-muted">
+        Funding, launches, hires, and partnerships from the most recent weekly pipeline
+        runs. Headlines link to the original story; mention chips link to the company
+        profile.
+      </p>
+
+      {spend && <SpendCard spend={spend} />}
+
+      {loadError && (
+        <div className="mt-6 rounded-md border border-error/40 bg-surface px-4 py-3 text-[13px] text-error">
+          Failed to load news: {loadError}
+        </div>
+      )}
+
+      {!loadError && items === null && (
+        <div className="mt-6 rounded-md border border-border bg-surface px-4 py-3 text-[13px] text-text-muted">
+          Loading news...
+        </div>
+      )}
+
+      {!loadError && items !== null && items.length === 0 && (
+        <div className="mt-6 rounded-md border border-border bg-surface px-4 py-8 text-center text-[13px] text-text-muted">
+          No news items yet. The pipeline runs weekly on Monday morning.
+        </div>
+      )}
+
+      {!loadError && items && items.length > 0 && (
+        <ul className="mt-6 space-y-3">
+          {items.map((item) => (
+            <NewsCard key={item.id} item={item} companyById={companyById} allCompanies={companies} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function SpendCard({ spend }: { spend: SpendSummary }) {
+  return (
+    <div className="mt-5 flex flex-wrap items-center gap-x-6 gap-y-2 rounded-xl border border-border bg-surface/60 px-4 py-3">
+      <div className="flex items-center gap-2 text-[12px] font-medium uppercase tracking-[0.14em] text-text-subtle">
+        <Sparkles className="h-3.5 w-3.5 text-accent" />
+        Pipeline cost - last 4 weeks
+      </div>
+      <div className="flex items-baseline gap-1.5 font-mono text-[13px] text-text-muted">
+        <span className="text-[18px] font-semibold tabular-nums text-text">
+          {formatUsd(spend.total_usd)}
+        </span>
+        <span>total</span>
+      </div>
+      <div className="flex items-baseline gap-1.5 font-mono text-[13px] text-text-muted">
+        <span className="text-[15px] font-semibold tabular-nums text-text">
+          {formatUsd(spend.average_usd)}
+        </span>
+        <span>per run avg</span>
+      </div>
+      <div className="flex items-baseline gap-1.5 font-mono text-[13px] text-text-muted">
+        <span className="text-[15px] font-semibold tabular-nums text-text">
+          {spend.run_count}
+        </span>
+        <span>runs</span>
+      </div>
+    </div>
+  );
+}
+
+function NewsCard({
+  item,
+  companyById,
+  allCompanies,
+}: {
+  item: NewsItem;
+  companyById: Map<string, Company>;
+  allCompanies: Company[];
+}) {
+  const date = item.published_at ? formatDate(item.published_at) : null;
+  const mentions = item.company_ids
+    .map((id) => companyById.get(id))
+    .filter((c): c is Company => Boolean(c));
+
+  return (
+    <li className="rounded-xl border border-border bg-surface/60 transition-colors hover:border-border-strong">
+      <div className="px-5 py-4">
+        <div className="flex flex-wrap items-baseline gap-2 text-[11px] font-medium uppercase tracking-[0.14em] text-text-subtle">
+          <span className="text-accent">{item.kind}</span>
+          {date && <span className="text-text-muted normal-case tracking-normal">{date}</span>}
+          <span className="text-text-subtle normal-case tracking-normal">
+            via {item.source_slug}
+          </span>
+        </div>
+        <h2 className="mt-2 text-[16px] font-semibold leading-snug text-text">
+          <a
+            href={item.source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-start gap-1.5 text-text transition-colors hover:text-accent"
+          >
+            {item.title}
+            <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-muted" />
+          </a>
+        </h2>
+        {item.summary && (
+          <p className="mt-2 text-[13px] leading-relaxed text-text-muted">
+            {cleanSummary(item.summary)}
+          </p>
+        )}
+        {mentions.length > 0 && (
+          <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-text-subtle">
+              Mentions
+            </span>
+            {mentions.map((c) => {
+              const slug = slugFor(c, allCompanies);
+              return (
+                <Link
+                  key={c.id}
+                  href={`/companies/${slug}`}
+                  className="rounded-md border border-border bg-surface-2 px-2 py-0.5 text-[11px] font-medium text-text transition-colors hover:border-accent hover:text-accent"
+                >
+                  {c.name}
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function cleanSummary(raw: string): string {
+  // Strip HTML tags and decode common entities. The pipeline sometimes ingests
+  // raw RSS HTML; we keep the text but drop the markup.
+  const stripped = raw
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(\d+);/g, (_m, code) => String.fromCharCode(Number(code)))
+    .replace(/\s+/g, " ")
+    .trim();
+  return stripped.length > 320 ? `${stripped.slice(0, 320).trimEnd()}...` : stripped;
+}
+
+function formatUsd(amount: number): string {
+  if (amount < 1) return `$${amount.toFixed(2)}`;
+  if (amount < 10) return `$${amount.toFixed(2)}`;
+  if (amount < 100) return `$${amount.toFixed(1)}`;
+  return `$${Math.round(amount)}`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const now = new Date();
+    const diffDays = Math.floor((now.getTime() - d.getTime()) / 86_400_000);
+    if (diffDays === 0) return "today";
+    if (diffDays === 1) return "yesterday";
+    if (diffDays < 7) return `${diffDays} days ago`;
+    if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
+    return d.toISOString().slice(0, 10);
+  } catch {
+    return iso.slice(0, 10);
+  }
+}

--- a/web/src/lib/news-server.ts
+++ b/web/src/lib/news-server.ts
@@ -1,0 +1,63 @@
+// Server-side helpers for fetching news + LLM spend summary.
+// Mirrors SupabaseSource.recent_news / llm_spend_summary in
+// src/ai_sector_watch/storage/data_source.py.
+
+import "server-only";
+
+import { sql } from "./db";
+import type { NewsItem } from "./types";
+
+type Row = Record<string, unknown>;
+
+export interface SpendSummary {
+  total_usd: number;
+  average_usd: number;
+  run_count: number;
+}
+
+function toIso(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") return value;
+  return null;
+}
+
+export async function listRecentNews(limit = 100): Promise<NewsItem[]> {
+  const rows = await sql<Row[]>`
+    SELECT id, source_slug, source_url, title, summary,
+           published_at, kind, company_ids
+    FROM news_items
+    ORDER BY published_at DESC NULLS LAST, fetched_at DESC
+    LIMIT ${limit}
+  `;
+  return rows.map((r) => ({
+    id: String(r.id),
+    source_slug: r.source_slug as string,
+    source_url: r.source_url as string,
+    title: r.title as string,
+    summary: (r.summary as string | null) ?? null,
+    published_at: toIso(r.published_at),
+    kind: r.kind as string,
+    company_ids: Array.isArray(r.company_ids) ? r.company_ids.map(String) : [],
+  }));
+}
+
+export async function getSpendSummary(): Promise<SpendSummary | null> {
+  const rows = await sql<Row[]>`
+    SELECT
+        COUNT(cost_usd)::int AS run_count,
+        SUM(cost_usd) AS total_usd,
+        AVG(cost_usd) AS average_usd
+    FROM ingest_events
+    WHERE kind = 'weekly_run'
+      AND cost_usd IS NOT NULL
+      AND fetched_at >= NOW() - INTERVAL '4 weeks'
+  `;
+  const r = rows[0];
+  if (!r || Number(r.run_count) === 0) return null;
+  return {
+    total_usd: Number(r.total_usd),
+    average_usd: Number(r.average_usd),
+    run_count: Number(r.run_count),
+  };
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -46,3 +46,14 @@ export interface Company {
   profile_verified_at: string | null;
   latest_funding_event: FundingEvent | null;
 }
+
+export interface NewsItem {
+  id: string;
+  source_slug: string;
+  source_url: string;
+  title: string;
+  summary: string | null;
+  published_at: string | null;
+  kind: string;
+  company_ids: string[];
+}


### PR DESCRIPTION
## Summary

Replace the `/news` stub with a real chronological feed + a pipeline cost summary card. (Phase 2B of the Streamlit replacement, partial — digest viewer deferred to a follow-up.)

## Why

Visitors landing on `/news` should see what the pipeline has been ingesting and how much it costs to run. The Streamlit version surfaces both; this PR brings them across.

## Stack-change note

No stack change. Builds on PR #70 (#67), #69 (#64), and #63 (#62). Live Streamlit dashboard at aimap.cliftonfamily.co is untouched.

## Branch base

Rebased on top of `claude-code/67-feature-phase-2d-about-page-accessibilit` (PR #70). After #63, #69, and #70 merge in order, this rebases cleanly onto main.

## Changes

- `feat(web)`: `/api/news?limit=100` mirrors `SupabaseSource.recent_news`; orders by `published_at` desc with `fetched_at` tiebreaker.
- `feat(web)`: `/api/spend-summary` mirrors `SupabaseSource.llm_spend_summary`; returns total / average / run_count over the last 4 weeks of `weekly_run` ingest events.
- `feat(web)`: `/news` page replaces the stub. Compact "Pipeline cost - last 4 weeks" card at the top (live: $0.43 total / $0.11 per run / 4 runs). News cards show kind eyebrow, relative date ("3 days ago"), source slug, title with external-link icon, HTML-stripped summary, and mention chips that link through to `/companies/[slug]` using the slug helper from #64.
- `feat(web)`: `NewsItem` added to `web/src/lib/types.ts`.

## Out of scope (deferred to a follow-up)

- Digest viewer with markdown rendering and a date selector. Needs a `react-markdown` install and either a `weekly_digests` table or a filesystem read of `data/digests/`. Cleaner as its own issue.
- Pagination beyond `limit=100`.

## Test plan

- [ ] `pytest -q` passes (no Python touched)
- [ ] `ruff check .` passes
- [ ] `black --check .` passes
- [x] `cd web && npm run build` passes (10 routes generated; new /api/news, /api/spend-summary)
- [x] `cd web && npm run lint` passes (0 errors, 0 warnings)
- [x] Manual smoke check via Claude Preview at 1280x900:
  - `/news` shows the cost card with live values
  - News cards render with HTML-stripped summaries (no `<p>` markup leaking through)
  - Clicking a mention chip navigates to `/companies/[slug]`
  - Clicking the title opens the source URL in a new tab
- [ ] `PROJECT_PROGRESS.md` updated *if* milestone — n/a, not yet (cutover #68 is the milestone)

## Multi-agent coordination

- [x] Followed [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md) pre-flight
- [x] Self-assigned to #65
- [x] Branch `claude-code/65-feature-phase-2b-news-feed-and-weekly-di`
- [x] Rebased onto #67's branch tip

## Related issues

Partially closes #65 (feed + spend; digest viewer remains)
Sibling issues: #64 (Companies, PR #69), #66 (Admin), #67 (Polish, PR #70)
Followed by: #68 (Azure cutover)
Tracker: #61
