### PR TITLE
[#66] Phase 2C: Admin queue with server-side auth

### DIFF
--- a/web/src/app/admin/login/page.tsx
+++ b/web/src/app/admin/login/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { isAdminAuthenticated } from "@/lib/admin-auth";
+import { LoginForm } from "@/components/admin/LoginForm";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Admin sign in",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminLoginPage() {
+  if (await isAdminAuthenticated()) redirect("/admin");
+  return (
+    <section className="mx-auto flex w-full max-w-[380px] flex-1 items-center px-5 py-16">
+      <div className="w-full">
+        <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-text-subtle">
+          Restricted
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold tracking-tight text-text">
+          Admin sign in
+        </h1>
+        <p className="mt-2 text-[13px] text-text-muted">
+          Enter the admin password to access the review queue. Sessions expire after 12 hours.
+        </p>
+        <div className="mt-6">
+          <LoginForm />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { isAdminAuthenticated } from "@/lib/admin-auth";
+import { getRejectedCount, listPendingCompanies } from "@/lib/admin-companies";
+import { AdminQueue } from "@/components/admin/AdminQueue";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Admin: review queue",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminPage() {
+  if (!(await isAdminAuthenticated())) redirect("/admin/login");
+
+  const [pending, rejectedCount] = await Promise.all([
+    listPendingCompanies(),
+    getRejectedCount(),
+  ]);
+
+  return (
+    <section className="mx-auto w-full max-w-[1100px] px-5 py-10">
+      <AdminQueue pending={pending} rejectedCount={rejectedCount} />
+    </section>
+  );
+}

--- a/web/src/app/api/admin/companies/[id]/promote/route.ts
+++ b/web/src/app/api/admin/companies/[id]/promote/route.ts
@@ -1,0 +1,36 @@
+// POST /api/admin/companies/[id]/promote
+// Auth: requires valid admin session cookie.
+
+import { NextResponse } from "next/server";
+
+import { isAdminAuthenticated } from "@/lib/admin-auth";
+import { logAdminAction, setCompanyStatus } from "@/lib/admin-companies";
+
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(_request: Request, { params }: Params) {
+  if (!(await isAdminAuthenticated())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Missing company id" }, { status: 400 });
+  }
+  try {
+    await setCompanyStatus(id, "verified");
+    await logAdminAction(id, "verified").catch(() => {
+      // Audit log is best-effort; do not block the action on its failure.
+    });
+    return NextResponse.json({ ok: true, id, status: "verified" });
+  } catch (err) {
+    console.error("POST /api/admin/companies/[id]/promote failed", err);
+    return NextResponse.json(
+      { error: "promote failed", detail: String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/companies/[id]/reject/route.ts
+++ b/web/src/app/api/admin/companies/[id]/reject/route.ts
@@ -1,0 +1,36 @@
+// POST /api/admin/companies/[id]/reject
+// Auth: requires valid admin session cookie.
+
+import { NextResponse } from "next/server";
+
+import { isAdminAuthenticated } from "@/lib/admin-auth";
+import { logAdminAction, setCompanyStatus } from "@/lib/admin-companies";
+
+export const dynamic = "force-dynamic";
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(_request: Request, { params }: Params) {
+  if (!(await isAdminAuthenticated())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Missing company id" }, { status: 400 });
+  }
+  try {
+    await setCompanyStatus(id, "rejected");
+    await logAdminAction(id, "rejected").catch(() => {
+      // Audit log is best-effort; do not block the action on its failure.
+    });
+    return NextResponse.json({ ok: true, id, status: "rejected" });
+  } catch (err) {
+    console.error("POST /api/admin/companies/[id]/reject failed", err);
+    return NextResponse.json(
+      { error: "reject failed", detail: String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/login/route.ts
+++ b/web/src/app/api/admin/login/route.ts
@@ -1,0 +1,42 @@
+// POST /api/admin/login
+// Body: { password: string }
+// Sets an HttpOnly session cookie if the password matches ADMIN_PASSWORD.
+
+import { NextResponse } from "next/server";
+
+import {
+  SESSION_COOKIE,
+  SESSION_TTL_SECONDS,
+  checkPassword,
+  makeSessionValue,
+} from "@/lib/admin-auth";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  let body: { password?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const password = (body.password ?? "").toString();
+  if (!password) {
+    return NextResponse.json({ error: "Password is required" }, { status: 400 });
+  }
+
+  if (!checkPassword(password)) {
+    return NextResponse.json({ error: "Wrong password" }, { status: 401 });
+  }
+
+  const value = makeSessionValue();
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(SESSION_COOKIE, value, {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: SESSION_TTL_SECONDS,
+  });
+  return res;
+}

--- a/web/src/app/api/admin/logout/route.ts
+++ b/web/src/app/api/admin/logout/route.ts
@@ -1,0 +1,20 @@
+// POST /api/admin/logout
+// Clears the session cookie.
+
+import { NextResponse } from "next/server";
+
+import { SESSION_COOKIE } from "@/lib/admin-auth";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(SESSION_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+  return res;
+}

--- a/web/src/components/admin/AdminQueue.tsx
+++ b/web/src/components/admin/AdminQueue.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Check, ExternalLink, LogOut, X } from "lucide-react";
+
+import { sectorLabel } from "@/lib/taxonomy";
+
+export interface PendingCompany {
+  id: string;
+  name: string;
+  country: string | null;
+  city: string | null;
+  stage: string | null;
+  founded_year: number | null;
+  summary: string | null;
+  sector_tags: string[];
+  founders: string[];
+  website: string | null;
+  discovery_source: string | null;
+  profile_sources: string[];
+}
+
+interface Props {
+  pending: PendingCompany[];
+  rejectedCount: number;
+}
+
+export function AdminQueue({ pending, rejectedCount }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function act(id: string, action: "promote" | "reject") {
+    setBusy(`${id}:${action}`);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/companies/${id}/${action}`, { method: "POST" });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error ?? `HTTP ${res.status}`);
+      }
+      router.refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function logout() {
+    await fetch("/api/admin/logout", { method: "POST" });
+    router.replace("/admin/login");
+    router.refresh();
+  }
+
+  return (
+    <>
+      <header className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-medium uppercase tracking-[0.16em] text-text-subtle">
+            Restricted - admin only
+          </div>
+          <h1 className="mt-1 text-3xl font-semibold tracking-tight text-text sm:text-4xl">
+            Review queue
+          </h1>
+          <p className="mt-2 max-w-2xl text-[14px] text-text-muted">
+            Auto-discovered candidates wait here for verification before they appear on the
+            public map. Promote moves a row to verified; reject keeps it in the database but
+            never surfaces it.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-[12px] text-text-muted">
+          <span>
+            <span className="font-mono tabular-nums text-text">{pending.length}</span> pending
+          </span>
+          <span aria-hidden className="text-border-strong">
+            ·
+          </span>
+          <span>
+            <span className="font-mono tabular-nums">{rejectedCount}</span> rejected
+          </span>
+          <button
+            type="button"
+            onClick={logout}
+            className="ml-2 inline-flex items-center gap-1 rounded-md border border-border-strong bg-surface px-2.5 py-1.5 text-[12px] font-medium text-text-muted transition-colors hover:border-accent hover:text-accent"
+          >
+            <LogOut className="h-3 w-3" />
+            Sign out
+          </button>
+        </div>
+      </header>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-5 rounded-md border border-error/40 bg-surface px-3 py-2 text-[13px] text-error"
+        >
+          {error}
+        </div>
+      )}
+
+      {pending.length === 0 ? (
+        <div className="mt-8 rounded-xl border border-border bg-surface p-8 text-center">
+          <div className="text-[14px] font-semibold text-text">Queue is clear</div>
+          <p className="mt-1 text-[13px] text-text-muted">
+            New candidates will appear here after each weekly pipeline run.
+          </p>
+        </div>
+      ) : (
+        <ul className="mt-8 space-y-3">
+          {pending.map((c) => (
+            <li
+              key={c.id}
+              className="overflow-hidden rounded-xl border border-border bg-surface"
+            >
+              <div className="px-5 py-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h2 className="text-[16px] font-semibold text-text">
+                      {c.website ? (
+                        <a
+                          href={c.website}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 hover:text-accent"
+                        >
+                          {c.name}
+                          <ExternalLink className="h-3 w-3 text-text-muted" />
+                        </a>
+                      ) : (
+                        c.name
+                      )}
+                    </h2>
+                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[12px] text-text-muted">
+                      {[c.city, c.country].filter(Boolean).join(", ") && (
+                        <span>{[c.city, c.country].filter(Boolean).join(", ")}</span>
+                      )}
+                      {c.stage && <span>{c.stage}</span>}
+                      {c.founded_year !== null && <span>Founded {c.founded_year}</span>}
+                      {c.discovery_source && (
+                        <span className="text-text-subtle">via {c.discovery_source}</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => act(c.id, "reject")}
+                      disabled={busy !== null}
+                      className="inline-flex items-center gap-1 rounded-md border border-border-strong bg-surface px-3 py-1.5 text-[12px] font-medium text-text-muted transition-colors hover:border-error hover:text-error disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <X className="h-3 w-3" />
+                      {busy === `${c.id}:reject` ? "..." : "Reject"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => act(c.id, "promote")}
+                      disabled={busy !== null}
+                      className="inline-flex items-center gap-1 rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-bg transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <Check className="h-3 w-3" />
+                      {busy === `${c.id}:promote` ? "..." : "Promote"}
+                    </button>
+                  </div>
+                </div>
+
+                {c.summary && (
+                  <p className="mt-3 text-[13px] leading-relaxed text-text">{c.summary}</p>
+                )}
+
+                {c.sector_tags.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-1.5">
+                    {c.sector_tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="rounded border border-border bg-surface-2 px-1.5 py-0.5 text-[11px] text-text-muted"
+                      >
+                        {sectorLabel(tag)}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                {c.founders.length > 0 && (
+                  <div className="mt-3 text-[12px] text-text-muted">
+                    <span className="font-medium uppercase tracking-[0.1em] text-text-subtle">
+                      Founders:
+                    </span>{" "}
+                    {c.founders.join(", ")}
+                  </div>
+                )}
+
+                {c.profile_sources.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-1.5 text-[11px]">
+                    <span className="font-medium uppercase tracking-[0.1em] text-text-subtle">
+                      Sources:
+                    </span>
+                    {c.profile_sources.slice(0, 5).map((src) => (
+                      <a
+                        key={src}
+                        href={src}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-text-muted underline-offset-2 hover:text-accent hover:underline"
+                      >
+                        {prettyHostname(src)}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-8 text-[12px] text-text-subtle">
+        <Link href="/" className="hover:text-text">
+          Back to public site
+        </Link>
+      </div>
+    </>
+  );
+}
+
+function prettyHostname(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}

--- a/web/src/components/admin/LoginForm.tsx
+++ b/web/src/components/admin/LoginForm.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { LogIn } from "lucide-react";
+
+export function LoginForm() {
+  const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/login", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+      if (res.ok) {
+        router.replace("/admin");
+        router.refresh();
+        return;
+      }
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      setError(data.error ?? `Sign-in failed (${res.status})`);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <label className="block">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-text-subtle">
+          Password
+        </span>
+        <input
+          type="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          className="mt-1 block w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-[13px] text-text outline-none focus:border-accent"
+          autoFocus
+        />
+      </label>
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-error/40 bg-surface px-3 py-2 text-[12px] text-error"
+        >
+          {error}
+        </div>
+      )}
+      <button
+        type="submit"
+        disabled={submitting || !password}
+        className="inline-flex items-center gap-1.5 rounded-md bg-accent px-4 py-2 text-[13px] font-semibold text-bg transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <LogIn className="h-3.5 w-3.5" />
+        {submitting ? "Signing in..." : "Sign in"}
+      </button>
+    </form>
+  );
+}

--- a/web/src/lib/admin-auth.ts
+++ b/web/src/lib/admin-auth.ts
@@ -1,0 +1,79 @@
+// Server-side admin auth. Never import from client code.
+//
+// Session cookie format: `<expMs>.<HMAC-SHA256(ADMIN_PASSWORD, expMs).hex>`
+// On each request we recompute the HMAC and compare in constant time.
+// The seed is ADMIN_PASSWORD itself, so rotating the password invalidates
+// every session for free.
+
+import "server-only";
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { cookies } from "next/headers";
+
+export const SESSION_COOKIE = "aisw_admin";
+const SESSION_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
+
+function getPassword(): string {
+  const pw = process.env.ADMIN_PASSWORD;
+  if (!pw) {
+    throw new Error("ADMIN_PASSWORD is not set; admin auth disabled.");
+  }
+  return pw;
+}
+
+function sign(expMs: number, password: string): string {
+  return createHmac("sha256", password).update(String(expMs)).digest("hex");
+}
+
+export function makeSessionValue(): string {
+  const expMs = Date.now() + SESSION_TTL_MS;
+  return `${expMs}.${sign(expMs, getPassword())}`;
+}
+
+export function isValidSession(value: string | undefined | null): boolean {
+  if (!value) return false;
+  const dot = value.indexOf(".");
+  if (dot < 0) return false;
+  const expStr = value.slice(0, dot);
+  const sig = value.slice(dot + 1);
+  const expMs = Number(expStr);
+  if (!Number.isFinite(expMs) || expMs < Date.now()) return false;
+
+  let pw: string;
+  try {
+    pw = getPassword();
+  } catch {
+    return false;
+  }
+
+  const expected = sign(expMs, pw);
+  if (sig.length !== expected.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(sig, "hex"), Buffer.from(expected, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+export function checkPassword(attempt: string): boolean {
+  let pw: string;
+  try {
+    pw = getPassword();
+  } catch {
+    return false;
+  }
+  if (attempt.length !== pw.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(attempt, "utf8"), Buffer.from(pw, "utf8"));
+  } catch {
+    return false;
+  }
+}
+
+export async function isAdminAuthenticated(): Promise<boolean> {
+  const store = await cookies();
+  const value = store.get(SESSION_COOKIE)?.value;
+  return isValidSession(value);
+}
+
+export const SESSION_TTL_SECONDS = Math.floor(SESSION_TTL_MS / 1000);

--- a/web/src/lib/admin-companies.ts
+++ b/web/src/lib/admin-companies.ts
@@ -1,0 +1,97 @@
+// Server-only Supabase mutations for admin actions.
+
+import "server-only";
+
+import { sql } from "./db";
+
+export type DiscoveryStatus = "verified" | "rejected";
+
+export async function setCompanyStatus(id: string, status: DiscoveryStatus): Promise<void> {
+  if (status === "verified") {
+    await sql`
+      UPDATE companies
+      SET discovery_status = 'verified', profile_verified_at = NOW()
+      WHERE id = ${id}
+    `;
+  } else {
+    await sql`
+      UPDATE companies
+      SET discovery_status = 'rejected'
+      WHERE id = ${id}
+    `;
+  }
+}
+
+export async function logAdminAction(
+  companyId: string,
+  status: DiscoveryStatus,
+): Promise<void> {
+  // Audit log: ingest_events with kind='admin_action'. payload_hash uses
+  // company_id + status + epoch_ms to ensure idempotent inserts even if the
+  // same action lands twice (the unique index on (kind, payload_hash) will
+  // dedupe).
+  const payloadHash = `${companyId}:${status}:${Date.now()}`;
+  await sql`
+    INSERT INTO ingest_events (kind, payload_hash, fetched_at, metadata)
+    VALUES (
+      'admin_action',
+      ${payloadHash},
+      NOW(),
+      jsonb_build_object('company_id', ${companyId}, 'status', ${status}, 'actor', 'admin_ui')
+    )
+    ON CONFLICT (kind, payload_hash) DO NOTHING
+  `;
+}
+
+interface PendingRow {
+  id: string;
+  name: string;
+  country: string | null;
+  city: string | null;
+  stage: string | null;
+  founded_year: number | null;
+  summary: string | null;
+  sector_tags: string[];
+  founders: string[];
+  website: string | null;
+  discovery_source: string | null;
+  profile_sources: string[];
+}
+
+export async function listPendingCompanies(): Promise<PendingRow[]> {
+  const rows = await sql<Record<string, unknown>[]>`
+    SELECT id, name, country, city, stage, founded_year, summary,
+           sector_tags, founders, website, discovery_source, profile_sources
+    FROM companies
+    WHERE discovery_status = 'auto_discovered_pending_review'
+    ORDER BY name
+  `;
+  return rows.map((r) => ({
+    id: String(r.id),
+    name: r.name as string,
+    country: (r.country as string | null) ?? null,
+    city: (r.city as string | null) ?? null,
+    stage: (r.stage as string | null) ?? null,
+    founded_year:
+      r.founded_year === null || r.founded_year === undefined
+        ? null
+        : Number(r.founded_year),
+    summary: (r.summary as string | null) ?? null,
+    sector_tags: Array.isArray(r.sector_tags) ? r.sector_tags.map(String) : [],
+    founders: Array.isArray(r.founders) ? r.founders.map(String) : [],
+    website: (r.website as string | null) ?? null,
+    discovery_source: (r.discovery_source as string | null) ?? null,
+    profile_sources: Array.isArray(r.profile_sources)
+      ? r.profile_sources.map(String)
+      : [],
+  }));
+}
+
+export async function getRejectedCount(): Promise<number> {
+  const rows = await sql<Record<string, unknown>[]>`
+    SELECT COUNT(*)::int AS n
+    FROM companies
+    WHERE discovery_status = 'rejected'
+  `;
+  return rows[0] ? Number(rows[0].n) : 0;
+}


### PR DESCRIPTION
## Summary

Replace the Streamlit `/Admin` page with a server-side-auth admin queue in the new web/ app. (Phase 2C of the Streamlit replacement.)

## Why

The admin queue is operationally critical: it is how `auto_discovered_pending_review` candidates become visible on the public map. We cannot cut over to web/ until this exists at parity.

## Changes

**Auth:**
- Reuses `ADMIN_PASSWORD` (no new env var). Cookie value is `<expMs>.<HMAC-SHA256(password, expMs).hex>` with a 12-hour TTL. Rotating the password invalidates every session for free.
- HttpOnly + `sameSite=strict` + `secure` in production.
- All comparisons go through `crypto.timingSafeEqual`.

**Routes:**
- `POST /api/admin/login` - 401 on wrong password, sets cookie on success
- `POST /api/admin/logout` - clears cookie
- `POST /api/admin/companies/[id]/promote` - sets `discovery_status='verified'` and stamps `profile_verified_at`. 401 without valid cookie.
- `POST /api/admin/companies/[id]/reject` - sets `discovery_status='rejected'`. 401 without valid cookie.
- Both mutation routes append an `admin_action` row to `ingest_events` for audit (best-effort; does not block the action on failure; uses `ON CONFLICT` to dedupe).

**Pages:**
- `/admin` - server component. Redirects to `/admin/login` if no session. Lists every pending candidate with full context (city, country, stage, founded year, summary, sectors, founders, sources). Promote / Reject buttons POST and refresh.
- `/admin/login` - server component. Redirects to `/admin` if already signed in. Focused password form.
- Both admin pages set `robots: { index: false, follow: false }`.

## Test plan

- [x] `cd web && npm run build` passes (16 routes, all admin endpoints registered)
- [x] `cd web && npm run lint` passes (0 errors, 0 warnings)
- [x] Manual smoke check via Claude Preview:
  - `/admin` without a session redirects to `/admin/login`
  - Login form renders
  - `POST /api/admin/login` with wrong password returns 401 + `{ error: 'Wrong password' }`
  - `POST /api/admin/companies/<id>/promote` without a session cookie returns 401 + `{ error: 'Unauthorized' }`
- [ ] First real promote/reject - **deferred to operator after merge** (no real Supabase writes were exercised in dev)

## First-promotion checklist (post-merge)

1. Sign in at `/admin/login` with `ADMIN_PASSWORD` from 1Password.
2. Verify the queue lists pending candidates (or shows "Queue is clear").
3. Pick one candidate, click **Promote**, confirm it disappears from the queue.
4. Reload `/companies` and `/map`; the promoted company should appear.
5. Spot-check the `ingest_events` table for an `admin_action` row.

## Related issues

Closes #66
Followed by: #68 (Azure cutover)
