### PR TITLE
[#74] fix: Dockerfile PORT=8000 to match Azure WEBSITES_PORT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:1.7
 #
-# Phase 3 cutover: this image now serves the Next.js app under web/, not the
+# Phase 3 cutover: this image serves the Next.js app under web/, not the
 # Streamlit dashboard under dashboard/. The Streamlit code stays in the repo
-# for one cooling-off release; the previous image lives at GHCR
-# `ghcr.io/scclifton/ai-sector-watch/ai-sector-watch:streamlit-final` for
-# rollback.
+# for one cooling-off release. For rollback, see docs/deployment.md - the
+# last known-good Streamlit image is in GHCR at the SHA tag for commit
+# f8f2aaefba1d6417b3be7ae32c71d9bf98ea0cb4 (it can also be retagged
+# :streamlit-final from any machine with docker access).
 #
 # Multi-stage:
 #   1. deps   - install npm deps once
@@ -39,7 +40,7 @@ WORKDIR /app
 
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
-    PORT=3000 \
+    PORT=8000 \
     HOSTNAME=0.0.0.0
 
 # Run as non-root.
@@ -56,12 +57,16 @@ COPY --from=build --chown=node-app:node-app /app/public ./public
 
 USER node-app
 
-# Azure App Service for Linux maps the inbound port via WEBSITES_PORT, which
-# the platform exposes to the container as PORT. Next.js standalone reads
-# PORT directly. EXPOSE is informational; the actual port is whatever PORT
-# resolves to at runtime (3000 by default; 8000 if WEBSITES_PORT is still
-# set to 8000 from the previous Streamlit container).
-EXPOSE 3000
+# Port contract with Azure App Service for Linux:
+# - WEBSITES_PORT (App Service config) tells Azure's reverse proxy which
+#   port to route inbound traffic to. The Streamlit-era App Service has
+#   WEBSITES_PORT=8000.
+# - Azure does NOT inject WEBSITES_PORT into the container env.
+# - The container must therefore listen on the port WEBSITES_PORT names.
+# We pin PORT=8000 above so Next.js standalone (which reads PORT) listens
+# on the same port Azure routes to. If WEBSITES_PORT is ever changed, this
+# ENV needs to follow.
+EXPOSE 8000
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["node", "server.js"]

--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -10,9 +10,9 @@ Chronological log of milestones: public features, closed Now/Next issues, live c
 - Phase 2B #65 / PR #71: News feed with HTML-stripped summaries, mention chips linking to companies, and a "Pipeline cost - last 4 weeks" card driven by ingest_events.
 - Phase 2C #66 / PR #72: Admin review queue at /admin with HMAC-signed session cookies seeded by ADMIN_PASSWORD, server-only mutation routes for promote / reject, and an audit log row in ingest_events for every action.
 - Phase 2D #67 / PR #70: /about methodology page with the architecture SVG, global focus rings + skip link, /map empty state, constellation hover-label flip.
-- Phase 3 #68: New multi-stage Dockerfile producing a Next.js standalone runtime, /api/health endpoint, /_stcore/health rewrite for backward compatibility, deploy.yml retargeted at web/**, rollback path via the `:streamlit-final` GHCR tag.
+- Phase 3 #68: New multi-stage Dockerfile producing a Next.js standalone runtime, /api/health endpoint, /_stcore/health rewrite for backward compatibility, deploy.yml retargeted at web/**. First cutover attempt rolled back due to a port mismatch (Dockerfile ENV PORT=3000 vs Azure WEBSITES_PORT=8000), fixed by #74 which pins ENV PORT=8000 to match the existing Azure config.
 
-**Live change:** aimap.cliftonfamily.co now serves the Next.js container. The Streamlit code stays under dashboard/ for one cooling-off release; remove in a follow-up.
+**Live change:** aimap.cliftonfamily.co now serves the Next.js container after the second cutover (#74). The Streamlit code stays under dashboard/ for one cooling-off release; remove in a follow-up.
 
 **Tested:**
 - `cd web && npm run build` clean (16 routes including /admin, /companies/[slug], /api/health).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,11 +6,17 @@ Production target: Azure Web App for Containers in subscription `Azure subscript
 
 ## Cutover from Streamlit to Next.js (Phase 3)
 
-The merge of #68 to `main` triggers `deploy.yml`, which builds the new Next.js Dockerfile, pushes to GHCR with `:latest` and `:<sha>` tags, and deploys to the existing App Service. The container honours the `PORT` env var that Azure sets from `WEBSITES_PORT`, so the cutover does not require any port change.
+The merge of the cutover PR to `main` triggers `deploy.yml`, which builds the Next.js Dockerfile, pushes to GHCR with `:latest` and `:<sha>` tags, and deploys to the existing App Service.
 
-### Manual steps before merge (one-time)
+### Port contract (read this first)
 
-These run from your laptop with `az login` already active. They are optional but recommended.
+Azure App Service uses **`WEBSITES_PORT`** (an App Service config setting) to tell its reverse proxy which container port to route inbound traffic to. Azure does **not** inject `WEBSITES_PORT` into the container's env — the container itself must listen on the matching port.
+
+For our App Service, `WEBSITES_PORT=8000` (inherited from the Streamlit era). The Next.js container therefore pins `ENV PORT=8000` in the Dockerfile, and Next.js standalone reads `PORT` to decide where to listen. The two must always match. **If you ever change `WEBSITES_PORT`, update the Dockerfile `ENV PORT` in lockstep.**
+
+The original Phase 3 cutover (PR #73) shipped with `ENV PORT=3000`, which did not match `WEBSITES_PORT=8000`. The container started fine but the reverse proxy could not reach it; we rolled back. Issue #74 / its PR fixed it. Before merging any cutover PR, double-check `grep PORT= Dockerfile` returns the value that matches `az webapp config appsettings list -g ai-sector-watch -n ai-sector-watch --query "[?name=='WEBSITES_PORT']"`.
+
+### Manual steps before merge (one-time, optional but recommended)
 
 ```bash
 RG=ai-sector-watch
@@ -18,8 +24,6 @@ APP=ai-sector-watch
 IMAGE_BASE=ghcr.io/scclifton/ai-sector-watch/ai-sector-watch
 
 # 1. Tag the current Streamlit image as :streamlit-final so we can roll back.
-#    Get the digest of whatever :latest currently points at (this should be
-#    the last green Streamlit deploy).
 docker pull "$IMAGE_BASE:latest"
 docker tag  "$IMAGE_BASE:latest" "$IMAGE_BASE:streamlit-final"
 docker push "$IMAGE_BASE:streamlit-final"
@@ -32,14 +36,6 @@ az webapp config set \
   --resource-group "$RG" \
   --name "$APP" \
   --generic-configurations '{"healthCheckPath": "/api/health"}'
-
-# 3. (Optional) Update WEBSITES_PORT to 3000. Not required: the new
-#    container reads PORT from the env, so leaving WEBSITES_PORT=8000
-#    just makes Next.js bind to 8000.
-az webapp config appsettings set \
-  --resource-group "$RG" \
-  --name "$APP" \
-  --settings WEBSITES_PORT=3000
 ```
 
 ### What happens on merge
@@ -47,8 +43,9 @@ az webapp config appsettings set \
 1. Push to `main` matches `web/**` or `Dockerfile`. `deploy.yml` runs.
 2. The job builds the multi-stage Next.js Dockerfile, pushes `:latest` and `:<sha>` to GHCR, and calls `azure/webapps-deploy@v3` against the same App Service.
 3. App Service pulls the new image and restarts the container.
-4. The container starts `node server.js` listening on `PORT` (`WEBSITES_PORT`'s value, default 3000).
-5. Within ~60s `https://aimap.cliftonfamily.co` should serve the new app.
+4. The container starts `node server.js` listening on `PORT` (8000 in our config).
+5. Azure's reverse proxy routes inbound traffic to port 8000, which the container is listening on.
+6. Within ~60-180s `https://aimap.cliftonfamily.co` should serve the new app.
 
 ### Smoke checks after cutover
 
@@ -63,13 +60,33 @@ curl -I  https://aimap.cliftonfamily.co               # 200, valid cert
 
 ### Rollback
 
-If anything goes wrong, redeploy `:streamlit-final`:
+Two options. Both swap the App Service container in ~60-120s.
+
+**A. By SHA tag (always available — `:<sha>` images never get garbage-collected by GHCR retention):**
 
 ```bash
+# The last green Streamlit deploy was commit f8f2aaefba1d6417b3be7ae32c71d9bf98ea0cb4
+# (Apr 28, "[#58] PR2: visual polish"). Confirmed working as of Apr 29 rollback.
 az webapp config container set \
   --resource-group ai-sector-watch \
   --name ai-sector-watch \
-  --container-image-name ghcr.io/scclifton/ai-sector-watch/ai-sector-watch:streamlit-final
+  --container-image-name ghcr.io/scclifton/ai-sector-watch/ai-sector-watch:f8f2aaefba1d6417b3be7ae32c71d9bf98ea0cb4
+```
+
+**B. By `:streamlit-final` floating tag** (one-time setup before the first cutover, then any future rollback is one short command):
+
+```bash
+# One-time: from any machine with docker installed and GHCR push access.
+IMAGE=ghcr.io/scclifton/ai-sector-watch/ai-sector-watch
+docker pull "$IMAGE:f8f2aaefba1d6417b3be7ae32c71d9bf98ea0cb4"
+docker tag  "$IMAGE:f8f2aaefba1d6417b3be7ae32c71d9bf98ea0cb4" "$IMAGE:streamlit-final"
+docker push "$IMAGE:streamlit-final"
+
+# Then any time:
+az webapp config container set \
+  --resource-group ai-sector-watch \
+  --name ai-sector-watch \
+  --container-image-name "$IMAGE:streamlit-final"
 ```
 
 Or trigger the previous green deploy via `gh workflow run` on a Streamlit-era SHA. Watch logs:

--- a/tests/test_dashboard_theme.py
+++ b/tests/test_dashboard_theme.py
@@ -72,3 +72,13 @@ def test_docker_image_builds_next_js_standalone() -> None:
     # Workflow triggers on web/, not on the old Streamlit-era paths.
     assert '"web/**"' in deploy
     assert '".streamlit/**"' not in deploy
+
+
+def test_docker_image_listens_on_websites_port() -> None:
+    """The container PORT must match the App Service WEBSITES_PORT (#74)."""
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    # Azure App Service routes traffic to WEBSITES_PORT, which is currently
+    # 8000 from the Streamlit era. Next.js standalone reads PORT and listens
+    # on it. The two must agree or the reverse proxy times out.
+    assert "PORT=8000" in dockerfile
+    assert "EXPOSE 8000" in dockerfile


### PR DESCRIPTION
## Summary

Fix the port mismatch that took the Phase 3 cutover down ~75s. Pin the Dockerfile to `ENV PORT=8000` so the container matches the existing Azure `WEBSITES_PORT=8000`.

## Why

PR #73 deploy reported success but `aimap.cliftonfamily.co` timed out. Root cause: my Dockerfile shipped `ENV PORT=3000`, Next.js standalone listened on 3000, and Azure's reverse proxy was routing to 8000 (WEBSITES_PORT inherited from the Streamlit era). Azure does **not** inject `WEBSITES_PORT` into the container env — that was my wrong assumption.

We rolled back to the last Streamlit image at commit `f8f2aae` via `az webapp config container set`. Live site is back up.

## Live-infrastructure note (AGENTS.md §4)

This PR will trigger another live cutover when merged — same as #73. No new Azure resources, no DNS change. Just a re-deploy of a new image to the same App Service. The first attempt failed because of the port mismatch documented above; this PR removes that mismatch.

## Changes

- **`Dockerfile`** `ENV PORT=8000` and `EXPOSE 8000`. Header comment updated to remove the now-incorrect `:streamlit-final` claim. Inline comment explains the WEBSITES_PORT contract.
- **`tests/test_dashboard_theme.py`** new `test_docker_image_listens_on_websites_port` asserts `PORT=8000` + `EXPOSE 8000` so future Dockerfile edits do not regress this contract.
- **`docs/deployment.md`** new "Port contract (read this first)" section explaining the WEBSITES_PORT contract and that Azure does not inject the value. Removes the misleading "no port change needed" claim from #68. Rollback section documents the SHA tag (always present in GHCR) as the primary rollback target, with `:streamlit-final` retagging as a one-time setup convenience.
- **`PROJECT_PROGRESS.md`** updated to record the port-mismatch incident and its fix.

## Test plan

- [ ] `pytest -q` passes — new test asserts the Dockerfile has `PORT=8000`
- [ ] `ruff check .` passes
- [ ] `black --check .` passes
- [ ] After merge: `https://aimap.cliftonfamily.co/api/health` returns 200 — **operator confirms post-merge**
- [ ] After merge: browser smoke check on home / map / companies / news / about / admin
- [x] `PROJECT_PROGRESS.md` updated (incident note appended to the Phase 3 milestone entry)

## Multi-agent coordination

- [x] Followed [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md) pre-flight
- [x] Self-assigned to #74
- [x] Branch `claude-code/74-bug-phase-3-cutover-container-listens-on`
- [x] Branched from latest `main` (post-#73 squash)

## Cutover plan when merging

1. Merge this PR.
2. Deploy workflow auto-runs (~5-10 min).
3. App Service pulls the new image and restarts.
4. Smoke check `aimap.cliftonfamily.co/api/health` → expect `{"ok":true,...}`.
5. If anything goes wrong, rollback by SHA tag from `docs/deployment.md`.

## Related issues

Closes #74
Follow-up to #68 / #73
