### PR TITLE
[#76] fix: ingest_events audit log + /Admin redirect

### DIFF
--- a/src/ai_sector_watch/storage/supabase_schema.sql
+++ b/src/ai_sector_watch/storage/supabase_schema.sql
@@ -186,6 +186,12 @@ CREATE TABLE IF NOT EXISTS ingest_events (
 CREATE INDEX IF NOT EXISTS ingest_events_fetched_idx
     ON ingest_events (fetched_at DESC);
 
+-- Structured per-event detail. Used by the admin UI's audit log
+-- (kind='admin_action') to capture which company was acted on, the
+-- resulting status, and the actor. Pipeline writers may also use it.
+ALTER TABLE ingest_events
+    ADD COLUMN IF NOT EXISTS metadata JSONB;
+
 -- =========================================================================
 -- updated_at trigger for companies
 -- =========================================================================

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -19,6 +19,15 @@ const nextConfig: NextConfig = {
       { source: "/_stcore/health", destination: "/api/health" },
     ];
   },
+  // Streamlit served the admin page at /Admin (derived from 90_Admin.py).
+  // Next.js routes are case-sensitive. Redirect anyone with the old URL
+  // bookmarked or in muscle memory to the canonical lowercase route.
+  async redirects() {
+    return [
+      { source: "/Admin", destination: "/admin", permanent: false },
+      { source: "/Admin/:path*", destination: "/admin/:path*", permanent: false },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/web/src/lib/admin-companies.ts
+++ b/web/src/lib/admin-companies.ts
@@ -26,20 +26,21 @@ export async function logAdminAction(
   companyId: string,
   status: DiscoveryStatus,
 ): Promise<void> {
-  // Audit log: ingest_events with kind='admin_action'. payload_hash uses
-  // company_id + status + epoch_ms to ensure idempotent inserts even if the
-  // same action lands twice (the unique index on (kind, payload_hash) will
-  // dedupe).
+  // Audit log: ingest_events with source_slug='admin_ui', kind='admin_action'.
+  // payload_hash bundles company_id + status + epoch_ms to keep each action
+  // distinct in time. The unique index on (source_slug, kind, payload_hash)
+  // dedupes if the same admin action lands twice.
   const payloadHash = `${companyId}:${status}:${Date.now()}`;
   await sql`
-    INSERT INTO ingest_events (kind, payload_hash, fetched_at, metadata)
+    INSERT INTO ingest_events (source_slug, kind, payload_hash, fetched_at, metadata)
     VALUES (
+      'admin_ui',
       'admin_action',
       ${payloadHash},
       NOW(),
-      jsonb_build_object('company_id', ${companyId}, 'status', ${status}, 'actor', 'admin_ui')
+      ${sql.json({ company_id: companyId, status, actor: "admin_ui" })}
     )
-    ON CONFLICT (kind, payload_hash) DO NOTHING
+    ON CONFLICT (source_slug, kind, payload_hash) DO NOTHING
   `;
 }
 


### PR DESCRIPTION
## Summary

Two small Phase 1-3 follow-ups: silently-broken admin audit log + Streamlit-bookmark-drift 404 on `/Admin`.

## Why

After the rollout, smoke-checking surfaced two latent bugs the test suite did not catch:

1. **Audit log silently dropped every admin action.** The `logAdminAction` INSERT referenced a `metadata` column that did not exist on `ingest_events`, missed the `NOT NULL source_slug`, and pointed `ON CONFLICT` at a constraint that did not match the actual unique index. The error was caught by `.catch(() => {})` so promote / reject still worked. But the 14 candidates promoted in the live admin queue on 2026-04-29 are not in `ingest_events` - we have no audit trail for that work.
2. **`/Admin` (capital A) returns 404.** Streamlit served the page at `/Admin` (derived from `90_Admin.py`). Next.js path matching is case-sensitive, so legacy bookmarks break.

## Changes

- **`supabase_schema.sql`** adds `ALTER TABLE ingest_events ADD COLUMN IF NOT EXISTS metadata JSONB`. Applied to production once (idempotent).
- **`web/src/lib/admin-companies.ts`**: `logAdminAction` INSERT now sets `source_slug='admin_ui'`, stores structured detail in the new `metadata` JSONB column, and uses the correct `ON CONFLICT (source_slug, kind, payload_hash)` clause.
- **`web/next.config.ts`** adds `redirects()` mapping `/Admin` and `/Admin/:path*` to lowercase canonical paths. Non-permanent (307) so we are not locked into cached redirects if the route ever changes.

## Live-infrastructure note

The schema migration was applied to production Supabase via `op run --env-file=.env.local -- node ... ALTER TABLE` before this PR opened. The ALTER is idempotent (`IF NOT EXISTS`); no risk if applied a second time. After this PR merges, the deploy workflow ships the code change that uses the column.

## Test plan

- [x] `cd web && npm run build` clean
- [x] `cd web && npm run lint` clean
- [x] `ingest_events.metadata` column verified present on production via `information_schema.columns` lookup
- [ ] After merge: `/Admin` returns 307 to `/admin` (operator confirms by hitting both URLs)
- [ ] After merge: a fresh promote / reject in the admin UI writes an `admin_action` row to `ingest_events` (operator confirms via spot-check query)

## Out of scope (genuinely)

- Backfilling the 14 missing audit rows from 2026-04-29. Possible by selecting `companies WHERE profile_verified_at >= '2026-04-29'` and INSERT-ing matching `admin_action` rows, but exact times are lost. The new code captures every future action correctly; the historical gap stays a one-time anomaly.
- `:streamlit-final` GHCR tag.
- News digest viewer.

## Related

Closes #76
Follow-up to #66 (admin queue) and #68 (Phase 3 cutover).
