### PR TITLE
feat(web): show company funding history

### DIFF
--- a/web/src/components/companies/CompaniesDirectory.tsx
+++ b/web/src/components/companies/CompaniesDirectory.tsx
@@ -13,13 +13,14 @@ import {
   paramsToFilters,
 } from "@/lib/filters";
 import { primarySectorHex, sectorLabel } from "@/lib/taxonomy";
-import { formatHeadcount, formatStage, formatUsd } from "@/lib/format";
+import { formatStage } from "@/lib/format";
 import { slugFor } from "@/lib/slug";
 import { cn } from "@/lib/cn";
 import type { Company } from "@/lib/types";
 
-type SortKey = "name" | "founded" | "raised" | "headcount";
+type SortKey = "name" | "founded";
 type SortDir = "asc" | "desc";
+const SORT_KEYS: SortKey[] = ["name", "founded"];
 
 export function CompaniesDirectory() {
   const router = useRouter();
@@ -48,7 +49,10 @@ export function CompaniesDirectory() {
     () => paramsToFilters(new URLSearchParams(searchParams.toString())),
     [searchParams],
   );
-  const sortKey = (searchParams.get("sort") as SortKey) || "name";
+  const requestedSort = searchParams.get("sort");
+  const sortKey = SORT_KEYS.includes(requestedSort as SortKey)
+    ? (requestedSort as SortKey)
+    : "name";
   const sortDir = (searchParams.get("dir") as SortDir) || "asc";
 
   const filtered = useMemo(
@@ -140,8 +144,6 @@ export function CompaniesDirectory() {
                   <SortableTh label="Name" active={sortKey} dir={sortDir} field="name" onSort={onSort} />
                   <th className="px-4 py-2 font-medium">Stage</th>
                   <SortableTh label="Founded" active={sortKey} dir={sortDir} field="founded" onSort={onSort} />
-                  <SortableTh label="Total raised" active={sortKey} dir={sortDir} field="raised" onSort={onSort} />
-                  <SortableTh label="Headcount" active={sortKey} dir={sortDir} field="headcount" onSort={onSort} />
                   <th className="px-4 py-2 font-medium">Sectors</th>
                   <th className="px-4 py-2 font-medium">Location</th>
                 </tr>
@@ -185,12 +187,6 @@ export function CompaniesDirectory() {
                       <td className="px-4 py-3 text-text-muted">{formatStage(c.stage) ?? "-"}</td>
                       <td className="px-4 py-3 text-text-muted tabular-nums">
                         {c.founded_year ?? "-"}
-                      </td>
-                      <td className="px-4 py-3 tabular-nums text-text">
-                        {formatUsd(c.total_raised_usd) ?? "-"}
-                      </td>
-                      <td className="px-4 py-3 text-text-muted tabular-nums">
-                        {formatHeadcount(c) ?? "-"}
                       </td>
                       <td className="px-4 py-3">
                         <div className="flex flex-wrap gap-1">
@@ -237,10 +233,6 @@ export function CompaniesDirectory() {
                     <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-[12px] text-text-muted tabular-nums">
                       {formatStage(c.stage) && <span>{formatStage(c.stage)}</span>}
                       {c.founded_year !== null && <span>Founded {c.founded_year}</span>}
-                      {formatUsd(c.total_raised_usd) && (
-                        <span className="text-text">{formatUsd(c.total_raised_usd)}</span>
-                      )}
-                      {formatHeadcount(c) && <span>{formatHeadcount(c)} people</span>}
                     </div>
                     <div className="mt-3 flex flex-wrap gap-1">
                       {c.sector_tags.slice(0, 3).map((tag) => (
@@ -314,22 +306,9 @@ function sortCompanies(items: Company[], key: SortKey, dir: SortDir): Company[] 
     case "founded":
       sorted.sort((a, b) => mult * cmpNullable(a.founded_year, b.founded_year));
       break;
-    case "raised":
-      sorted.sort((a, b) => mult * cmpNullable(a.total_raised_usd, b.total_raised_usd));
-      break;
-    case "headcount":
-      sorted.sort((a, b) => mult * cmpNullable(headcountForSort(a), headcountForSort(b)));
-      break;
     case "name":
     default:
       sorted.sort((a, b) => mult * a.name.localeCompare(b.name));
   }
   return sorted;
-}
-
-function headcountForSort(c: Company): number | null {
-  if (c.headcount_estimate !== null) return c.headcount_estimate;
-  if (c.headcount_max !== null) return c.headcount_max;
-  if (c.headcount_min !== null) return c.headcount_min;
-  return null;
 }

--- a/web/src/components/companies/CompanyProfile.tsx
+++ b/web/src/components/companies/CompanyProfile.tsx
@@ -4,7 +4,7 @@ import { ArrowLeft, ExternalLink } from "lucide-react";
 import type { Company } from "@/lib/types";
 import { primarySectorHex, sectorLabel } from "@/lib/taxonomy";
 import {
-  formatHeadcount,
+  formatFundingAmount,
   formatLatestFunding,
   formatLocation,
   formatStage,
@@ -20,9 +20,7 @@ export function CompanyProfile({ company }: Props) {
   const location = formatLocation(company);
   const stage = formatStage(company.stage);
   const latestFunding = formatLatestFunding(company.latest_funding_event);
-  const totalRaised = formatUsd(company.total_raised_usd);
   const valuation = formatUsd(company.valuation_usd);
-  const headcount = formatHeadcount(company);
 
   return (
     <article className="mx-auto w-full max-w-[900px] px-5 py-10">
@@ -63,9 +61,7 @@ export function CompanyProfile({ company }: Props) {
           <dl className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
             <Stat label="Stage" value={stage} />
             <Stat label="Founded" value={company.founded_year !== null ? String(company.founded_year) : null} />
-            <Stat label="Total raised" value={totalRaised} highlight />
             <Stat label="Valuation" value={valuation} highlight />
-            <Stat label="Headcount" value={headcount} />
             <Stat label="Verified" value={company.profile_verified_at?.slice(0, 10) ?? null} />
             {latestFunding && (
               <div className="col-span-2">
@@ -91,6 +87,56 @@ export function CompanyProfile({ company }: Props) {
               <div className="mt-6">
                 <Label>Founders</Label>
                 <p className="mt-2 text-[14px] text-text">{company.founders.join(", ")}</p>
+              </div>
+            )}
+
+            {company.funding_events.length > 0 && (
+              <div className="mt-6">
+                <Label>Funding history</Label>
+                <ol className="mt-3 divide-y divide-border rounded-lg border border-border bg-bg/30">
+                  {company.funding_events.map((event) => (
+                    <li
+                      key={event.id}
+                      className="grid gap-2 px-3 py-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                          <span className="text-[14px] font-semibold text-text">
+                            {formatFundingAmount(event) ?? "Amount undisclosed"}
+                          </span>
+                          {formatStage(event.stage) && (
+                            <span className="text-[12px] text-text-muted">
+                              {formatStage(event.stage)}
+                            </span>
+                          )}
+                        </div>
+                        {(event.lead_investor || event.investors.length > 0) && (
+                          <p className="mt-1 text-[12px] text-text-muted">
+                            {[event.lead_investor, ...event.investors].filter(Boolean).join(", ")}
+                          </p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-3 text-[12px] text-text-muted sm:justify-end">
+                        {event.announced_on && (
+                          <span className="font-mono tabular-nums">
+                            {event.announced_on.slice(0, 10)}
+                          </span>
+                        )}
+                        {event.source_url && (
+                          <a
+                            href={event.source_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-accent hover:text-accent-hover"
+                          >
+                            Source
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ol>
               </div>
             )}
 

--- a/web/src/lib/companies-server.ts
+++ b/web/src/lib/companies-server.ts
@@ -44,6 +44,22 @@ function buildFunding(row: Row): FundingEvent | null {
   };
 }
 
+function buildFundingEvents(value: unknown): FundingEvent[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is Row => item !== null && typeof item === "object")
+    .map((item) => ({
+      id: String(item.id),
+      announced_on: toIsoDate(item.announced_on),
+      stage: (item.stage as string | null) ?? null,
+      amount_usd: toNumber(item.amount_usd),
+      currency_raw: (item.currency_raw as string | null) ?? null,
+      lead_investor: (item.lead_investor as string | null) ?? null,
+      investors: toStringArray(item.investors),
+      source_url: (item.source_url as string | null) ?? null,
+    }));
+}
+
 function buildCompany(row: Row): Company {
   return {
     id: String(row.id),
@@ -77,6 +93,7 @@ function buildCompany(row: Row): Company {
     profile_sources: toStringArray(row.profile_sources),
     profile_verified_at: toIsoDate(row.profile_verified_at),
     latest_funding_event: buildFunding(row),
+    funding_events: buildFundingEvents(row.funding_events),
   };
 }
 
@@ -91,7 +108,8 @@ export async function listVerifiedCompanies(): Promise<Company[]> {
         fe.currency_raw AS latest_funding_currency_raw,
         fe.lead_investor AS latest_funding_lead_investor,
         fe.investors AS latest_funding_investors,
-        fe.source_url AS latest_funding_source_url
+        fe.source_url AS latest_funding_source_url,
+        COALESCE(funding.funding_events, '[]'::jsonb) AS funding_events
     FROM companies c
     LEFT JOIN LATERAL (
         SELECT id, announced_on, stage, amount_usd, currency_raw,
@@ -101,6 +119,23 @@ export async function listVerifiedCompanies(): Promise<Company[]> {
         ORDER BY announced_on DESC NULLS LAST, created_at DESC
         LIMIT 1
     ) fe ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT jsonb_agg(
+            jsonb_build_object(
+                'id', id,
+                'announced_on', announced_on,
+                'stage', stage,
+                'amount_usd', amount_usd,
+                'currency_raw', currency_raw,
+                'lead_investor', lead_investor,
+                'investors', investors,
+                'source_url', source_url
+            )
+            ORDER BY announced_on DESC NULLS LAST, created_at DESC
+        ) AS funding_events
+        FROM funding_events
+        WHERE company_id = c.id
+    ) funding ON TRUE
     WHERE c.discovery_status = 'verified'
     ORDER BY c.name
   `;

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -44,13 +44,18 @@ export function formatHeadcount(c: Company): string | null {
   return null;
 }
 
+export function formatFundingAmount(event: FundingEvent | null): string | null {
+  if (!event) return null;
+  return formatUsd(event.amount_usd) ?? event.currency_raw;
+}
+
 export function formatLatestFunding(event: FundingEvent | null): string | null {
   if (!event) return null;
   const bits: string[] = [];
   const stageLabel = formatStage(event.stage);
   if (stageLabel) bits.push(stageLabel);
   if (event.announced_on) bits.push(event.announced_on.slice(0, 10));
-  const amount = formatUsd(event.amount_usd);
+  const amount = formatFundingAmount(event);
   if (amount) bits.push(amount);
   return bits.length > 0 ? bits.join(", ") : null;
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -45,6 +45,7 @@ export interface Company {
   profile_sources: string[];
   profile_verified_at: string | null;
   latest_funding_event: FundingEvent | null;
+  funding_events: FundingEvent[];
 }
 
 export interface NewsItem {


### PR DESCRIPTION
## Summary
- Remove the sparse Total raised and Headcount columns from the companies directory table and mobile cards.
- Extend `/api/companies` to return each verified company's full funding event history, not only the latest event.
- Update company profile pages to show latest funding with raw report amounts and a sourced Funding history section.

## Why
Cut Through report imports write reviewed round data to `funding_events`. The previous companies page read `companies.total_raised_usd` and headcount fields, which are intentionally separate profile aggregates and were not populated by the Cut Through workflow.

## Verification
- `npm run lint`
- `npm run build`
- Local smoke with `op run --env-file=.env.local -- npm run dev -- --hostname 127.0.0.1 --port 3010`
- Verified `/api/companies` includes `funding_events[]` for Relevance AI, Advanced Navigation, Harrison.ai, and Kismet.
- Verified `/companies` no longer shows Total raised or Headcount columns.
- Verified `/companies/relevance-ai` renders Latest funding and Funding history with the Cut Through source link.

## Notes
Pending companies remain hidden from the public companies page until promoted in `/admin`, preserving the verified-only public gate.