### PR TITLE
docs: document Cut Through import operations

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -554,3 +554,40 @@ Chronological log of milestones: public features, closed Now/Next issues, live c
 - The production GHCR image does not exist yet, so the dashboard URL currently returns `HTTP/2 503`. Issue #6 (deploy.yml: build container, push to GHCR, deploy) closes this. Once that runs, the configured image resolves and the dashboard serves on port 8000.
 - OIDC federated credential and the `AZURE_CLIENT_ID` / `TENANT_ID` / `SUBSCRIPTION_ID` GitHub secrets (deployment.md "OIDC federated credential" section) are deferred to whichever issue wires `deploy.yml` end-to-end.
 - Custom domain `aimap.cliftonfamily.co` and TLS binding are deferred to issue #7 (DNS).
+
+## 2026-04-29 - Cut Through import and funding display
+
+**Shipped:**
+- Added a reviewed Cut Through Quarterly import workflow:
+  `scripts/discover_cut_through_reports.py`,
+  `scripts/extract_cut_through_report.py`, and
+  `scripts/apply_cut_through_import.py`.
+- Generated reviewed artifacts under `docs/data-audits/` for selected Cut
+  Through Quarterly reports and applied the approved payload to Supabase.
+- Added `funding_events` to the public companies API and company profile pages.
+  Detail pages now show latest funding and sourced funding history.
+- Removed `Total raised` and `Headcount` from the public company directory.
+  The directory now focuses on name, stage, founded year, sectors, and
+  location.
+
+**Live data changes:**
+- 19 funding events upserted from reviewed Cut Through artifacts.
+- 12 companies inserted as `auto_discovered_pending_review`.
+- 2 verified companies received reviewed stage updates:
+  Relevance AI to `series_b_plus`, Lyrebird Health to `series_a`.
+- Affected live rows were snapshotted before apply at
+  `docs/data-audits/snapshots/20260429T010852Z-cut-through-import-snapshot.json`.
+
+**Tested:**
+- `pytest -q`: pass, with two live Supabase tests skipped when local
+  `SUPABASE_DB_URL` was unset.
+- `ruff check .`: pass.
+- `black --check .`: pass.
+- `npm run lint`: pass for the web app.
+- `npm run build`: pass for the web app.
+- GitHub Actions `pytest`: pass on `main`.
+- Azure deploy: pass after the web funding-history merge.
+- Live smoke: `https://aimap.cliftonfamily.co/companies` renders without the
+  `Total raised` or `Headcount` columns, and
+  `https://aimap.cliftonfamily.co/companies/relevance-ai` shows founded year,
+  latest funding, and funding history.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -110,6 +110,56 @@ Safety gates:
 - Live apply refuses unresolved `op://` Supabase references.
 - Collaboration opportunities stay in the audit report until reviewed.
 
+## Importing Cut Through reports
+
+Use this when Cut Through Quarterly reports should be used to improve company
+stage and funding history. This workflow is deliberately separate from the
+weekly pipeline: discovery and extraction write review artifacts first, and
+Supabase changes happen only through an explicit apply step.
+
+Discover available quarterly reports:
+
+```bash
+op run --account my.1password.com --env-file=.env.local -- python scripts/discover_cut_through_reports.py --quarterly-only --output docs/data-audits/YYYY-MM-DD-cut-through-reports.json
+```
+
+Extract one or two selected PDFs into review artifacts:
+
+```bash
+op run --account my.1password.com --env-file=.env.local -- python scripts/extract_cut_through_report.py --report-url https://www.cutthrough.com/insights/cut-through-quarterly-1q-2026 --artifact-suffix 1q-2026
+```
+
+Review the generated Markdown, CSV, and JSON under `docs/data-audits/`. Keep
+rows as `needs_review` until the company and funding event are acceptable for
+the live dataset. For bare `$` report amounts, keep the value in
+`currency_raw` and leave `amount_usd` empty unless the report explicitly states
+the currency.
+
+Dry-run the reviewed payload:
+
+```bash
+op run --account my.1password.com --env-file=.env.local -- python scripts/apply_cut_through_import.py docs/data-audits/YYYY-MM-DD-cut-through-import-reviewed.json
+```
+
+Apply only after review:
+
+```bash
+op run --account my.1password.com --env-file=.env.local -- python scripts/apply_cut_through_import.py docs/data-audits/YYYY-MM-DD-cut-through-import-reviewed.json --apply
+```
+
+Safety gates:
+- Discovery and extraction never write Supabase.
+- Apply defaults to dry run and refuses unresolved `op://` Supabase references.
+- A snapshot of affected company and funding rows is written under
+  `docs/data-audits/snapshots/` before any live write.
+- New companies are inserted only as `auto_discovered_pending_review`.
+- Existing verified companies can receive reviewed funding events and reviewed
+  stage updates.
+- The public app continues to rely on `discovery_status = 'verified'`, so
+  pending companies stay out of the public map and company directory.
+- Keep runs bounded. Start with one or two reports to control Firecrawl and LLM
+  spend.
+
 ## Cost guardrails
 
 - The pipeline hard-caps Anthropic spend per run via `ANTHROPIC_BUDGET_USD_PER_RUN` (default $2). When the cap is hit mid-run, the orchestrator records a `partial` ingest event and writes a digest of what it managed to do.

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -21,6 +21,16 @@ To add a source: create a new module under `src/ai_sector_watch/sources/` that s
 | huggingface_papers | https://huggingface.co/api/daily_papers | API JSON | Medium | Custom JSON fetcher, not RSS |
 | yc_launches | https://www.ycombinator.com/launches/feed.atom | Launches | Low |  |
 
+## Reviewed manual sources
+
+These sources are not part of the weekly automated pipeline. They are operator
+workflows that produce reviewed artifacts first, then require an explicit apply
+step before any Supabase writes.
+
+| Slug | URL | Type | ANZ relevance | Notes |
+|---|---|---|---|---|
+| cut_through_quarterly | https://www.cutthrough.com/insights | Quarterly VC reports | High | Manual reviewed import via `scripts/discover_cut_through_reports.py`, `scripts/extract_cut_through_report.py`, and `scripts/apply_cut_through_import.py`. PDF parsing uses Firecrawl. New companies are inserted only as `auto_discovered_pending_review`; verified rows can receive reviewed stage or funding updates. |
+
 ## Conventions
 
 - One fetch per source per weekly run.


### PR DESCRIPTION
## Summary
- document Cut Through as a reviewed manual source
- add Cut Through discover/extract/apply runbook and safety gates
- record the Cut Through import and funding-display milestone

## Verification
- docs-only change; no code paths changed