### PR TITLE
[#84] Remove source provenance from public companies API

### DIFF
--- a/web/src/lib/companies-server.ts
+++ b/web/src/lib/companies-server.ts
@@ -40,7 +40,6 @@ function buildFunding(row: Row): FundingEvent | null {
     currency_raw: (row.latest_funding_currency_raw as string | null) ?? null,
     lead_investor: (row.latest_funding_lead_investor as string | null) ?? null,
     investors: toStringArray(row.latest_funding_investors),
-    source_url: (row.latest_funding_source_url as string | null) ?? null,
   };
 }
 
@@ -56,7 +55,6 @@ function buildFundingEvents(value: unknown): FundingEvent[] {
       currency_raw: (item.currency_raw as string | null) ?? null,
       lead_investor: (item.lead_investor as string | null) ?? null,
       investors: toStringArray(item.investors),
-      source_url: (item.source_url as string | null) ?? null,
     }));
 }
 
@@ -73,24 +71,18 @@ function buildCompany(row: Row): Company {
     stage: (row.stage as string | null) ?? null,
     founded_year: toNumber(row.founded_year),
     summary: (row.summary as string | null) ?? null,
-    discovery_status: row.discovery_status as string,
-    discovery_source: (row.discovery_source as string | null) ?? null,
     founders: toStringArray(row.founders),
     total_raised_usd: toNumber(row.total_raised_usd),
     total_raised_currency_raw: (row.total_raised_currency_raw as string | null) ?? null,
     total_raised_as_of: toIsoDate(row.total_raised_as_of),
-    total_raised_source_url: (row.total_raised_source_url as string | null) ?? null,
     valuation_usd: toNumber(row.valuation_usd),
     valuation_currency_raw: (row.valuation_currency_raw as string | null) ?? null,
     valuation_as_of: toIsoDate(row.valuation_as_of),
-    valuation_source_url: (row.valuation_source_url as string | null) ?? null,
     headcount_estimate: toNumber(row.headcount_estimate),
     headcount_min: toNumber(row.headcount_min),
     headcount_max: toNumber(row.headcount_max),
     headcount_as_of: toIsoDate(row.headcount_as_of),
-    headcount_source_url: (row.headcount_source_url as string | null) ?? null,
     profile_confidence: toNumber(row.profile_confidence),
-    profile_sources: toStringArray(row.profile_sources),
     profile_verified_at: toIsoDate(row.profile_verified_at),
     latest_funding_event: buildFunding(row),
     funding_events: buildFundingEvents(row.funding_events),
@@ -100,7 +92,30 @@ function buildCompany(row: Row): Company {
 export async function listVerifiedCompanies(): Promise<Company[]> {
   const rows = await sql<Row[]>`
     SELECT
-        c.*,
+        c.id,
+        c.name,
+        c.country,
+        c.city,
+        c.lat,
+        c.lon,
+        c.website,
+        c.sector_tags,
+        c.stage,
+        c.founded_year,
+        c.summary,
+        c.founders,
+        c.total_raised_usd,
+        c.total_raised_currency_raw,
+        c.total_raised_as_of,
+        c.valuation_usd,
+        c.valuation_currency_raw,
+        c.valuation_as_of,
+        c.headcount_estimate,
+        c.headcount_min,
+        c.headcount_max,
+        c.headcount_as_of,
+        c.profile_confidence,
+        c.profile_verified_at,
         fe.id AS latest_funding_id,
         fe.announced_on AS latest_funding_announced_on,
         fe.stage AS latest_funding_stage,
@@ -108,12 +123,11 @@ export async function listVerifiedCompanies(): Promise<Company[]> {
         fe.currency_raw AS latest_funding_currency_raw,
         fe.lead_investor AS latest_funding_lead_investor,
         fe.investors AS latest_funding_investors,
-        fe.source_url AS latest_funding_source_url,
         COALESCE(funding.funding_events, '[]'::jsonb) AS funding_events
     FROM companies c
     LEFT JOIN LATERAL (
         SELECT id, announced_on, stage, amount_usd, currency_raw,
-               lead_investor, investors, source_url, created_at
+               lead_investor, investors, created_at
         FROM funding_events
         WHERE company_id = c.id
         ORDER BY announced_on DESC NULLS LAST, created_at DESC
@@ -128,8 +142,7 @@ export async function listVerifiedCompanies(): Promise<Company[]> {
                 'amount_usd', amount_usd,
                 'currency_raw', currency_raw,
                 'lead_investor', lead_investor,
-                'investors', investors,
-                'source_url', source_url
+                'investors', investors
             )
             ORDER BY announced_on DESC NULLS LAST, created_at DESC
         ) AS funding_events

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -10,7 +10,6 @@ export interface FundingEvent {
   currency_raw: string | null;
   lead_investor: string | null;
   investors: string[];
-  source_url: string | null;
 }
 
 export interface Company {
@@ -25,24 +24,18 @@ export interface Company {
   stage: Stage | string | null;
   founded_year: number | null;
   summary: string | null;
-  discovery_status: string;
-  discovery_source: string | null;
   founders: string[];
   total_raised_usd: number | null;
   total_raised_currency_raw: string | null;
   total_raised_as_of: string | null;
-  total_raised_source_url: string | null;
   valuation_usd: number | null;
   valuation_currency_raw: string | null;
   valuation_as_of: string | null;
-  valuation_source_url: string | null;
   headcount_estimate: number | null;
   headcount_min: number | null;
   headcount_max: number | null;
   headcount_as_of: string | null;
-  headcount_source_url: string | null;
   profile_confidence: number | null;
-  profile_sources: string[];
   profile_verified_at: string | null;
   latest_funding_event: FundingEvent | null;
   funding_events: FundingEvent[];


### PR DESCRIPTION
## Summary

Removes source provenance fields from the public `/api/companies` response.

## Why

PR #83 removed source drill-downs from the public UI, but the live API still returned provenance and evidence fields such as `discovery_source`, `profile_sources`, and funding `source_url`. That endpoint is public, so the payload should only include fields required by public pages.

## Changes

- Replace `SELECT c.*` with an explicit public field list.
- Stop serializing company provenance fields and source URL fields.
- Stop serializing funding event source URLs in public company payloads.
- Leave admin APIs and news story links unchanged.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes

## Related issues

Closes #84
