### PR TITLE
[#89] [feature] apply 39 verified deep-research company updates to live Supabase

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -15,6 +15,16 @@ contact details out of this file. Routine fixes belong in PR bodies.
 
 ## Recent Milestones
 
+### 2026-04-30: Deep-Research Profile Refresh
+
+- Applied a manual deep-research verification pass across 39 verified
+  companies, writing richer summaries, current funding (with as-of dates and
+  source URLs), updated headcount, founded years, stages, and cities.
+- Each updated row carries a stamped `profile_verified_at` and a confidence
+  score so downstream surfaces can show provenance.
+- Companies flagged as defunct, non-ANZ, or non-AI were captured in a separate
+  triage artifact and will be rejected via a follow-up change.
+
 ### 2026-04-29: Custom Web Dashboard
 
 - Replaced the initial Streamlit-first public experience with a custom Next.js


### PR DESCRIPTION
## Summary

What this PR does in one or two sentences.

## Why

What problem does it solve? What does it enable?

## Changes

- ...
- ...
- ...

## Test plan

- [ ] `pytest -q` passes
- [ ] `ruff check .` passes
- [ ] `black --check .` passes
- [ ] Manual smoke check (describe)
- [ ] `PROJECT_PROGRESS.md` updated *if* this is a milestone (closes Now/Next issue, ships public feature, breaks something). Otherwise leave alone.

## Multi-agent coordination

- [ ] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [ ] I am the assignee on the linked issue
- [ ] Branch is named `<tool>/<issue-number>-<slug>`
- [ ] Rebased on latest `main` (no merge conflicts with other in-flight PRs)

## Screenshots

(If this changes the dashboard.)

## Related issues

Closes #

Closes #89

## What this PR does

Records the milestone for a deep-research verification refresh that updated
39 verified companies on live Supabase. The data write happened operationally
via `scripts/apply_company_profile_updates.py --apply` against a reviewed
apply JSON. This commit only updates `PROJECT_PROGRESS.md` to reflect that.

## Apply summary

- Companies updated: 39
- Field-writes:      491 (incl. profile_verified_at stamp per row)
- Errors:            0
- Source artifact:   `data/verification/apply_20260429T223923Z.json` (gitignored, kept locally)

## Spot-check

Confirmed against live Supabase that the following rows show updated summary,
headcount, total raised, stage, founded year, city, and verified-at timestamp:

- Heidi Health (481 staff, US$96.6M, Series B+)
- Halter (250 staff, US$290M, Series B+)
- Auror (289 staff, US$67.9M, Series B+)

## Follow-ups

- Issue B: reject the 16 deep-research-flagged non-ANZ / defunct / non-AI companies.
- Issue C: drop `founders` from the public profile and verification flow.
- Re-run prompt: covers the 4 first-listed companies Gemini DR omitted (AutoGrab, Advanced Navigation, Cortical Labs, Atlassian).
- Parser hardening: normalise string confidence levels ("high"/"medium"/"low") to floats so we don't hit the runtime type error that surfaced today.
