### PR TITLE
[#91] [feature] reject 16 deep-research-flagged non-ANZ / defunct / non-AI companies

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -15,6 +15,14 @@ contact details out of this file. Routine fixes belong in PR bodies.
 
 ## Recent Milestones
 
+### 2026-04-30: Rejected 16 Out-Of-Scope Companies
+
+- Removed 16 companies from the public map after a deep-research review found
+  them defunct, headquartered outside Australia or New Zealand, or not
+  AI-focused.
+- Added `scripts/apply_company_rejections.py` for repeatable, dry-run-by-default
+  rejection apply, with per-row audit captured in `ingest_events`.
+
 ### 2026-04-29: Custom Web Dashboard
 
 - Replaced the initial Streamlit-first public experience with a custom Next.js

--- a/scripts/apply_company_rejections.py
+++ b/scripts/apply_company_rejections.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Apply reviewed company rejections to live Supabase.
+
+Reads a flags JSON in the shape produced by `parse_verification_responses.py`,
+filters to entries with `verdict = 'flag_for_rejection'`, and sets
+`discovery_status = 'rejected'` for each via the existing
+`supabase_db.set_company_status` helper. Dry-run by default.
+
+Usage:
+    python scripts/apply_company_rejections.py data/verification/flags_<ts>.json
+    op run --env-file=.env.local -- python scripts/apply_company_rejections.py data/verification/flags_<ts>.json --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from ai_sector_watch.config import configure_logging  # noqa: E402
+from ai_sector_watch.storage import supabase_db  # noqa: E402
+
+LOGGER = logging.getLogger("apply_company_rejections")
+
+REJECTION_VERDICT = "flag_for_rejection"
+ADMIN_SOURCE = "verification_rejection_apply"
+
+
+@dataclass
+class RejectSummary:
+    """Operator-facing summary for a rejection apply run."""
+
+    input_path: str
+    apply: bool
+    candidates_seen: int = 0
+    rejected: int = 0
+    skipped_non_rejection: int = 0
+    errors: list[str] = field(default_factory=list)
+    rejected_ids: list[str] = field(default_factory=list)
+
+
+def _load_payload(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_payload(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    companies = payload.get("companies")
+    if not isinstance(companies, list):
+        return ["payload must contain a companies list"]
+    for index, company in enumerate(companies):
+        if not isinstance(company, dict):
+            errors.append(f"companies[{index}] must be an object")
+            continue
+        if not company.get("id"):
+            errors.append(f"companies[{index}] missing id")
+    return errors
+
+
+def _op_env_is_resolved() -> bool:
+    db_url = os.environ.get("SUPABASE_DB_URL", "")
+    return bool(db_url) and not db_url.startswith("op://")
+
+
+def select_rejection_candidates(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the entries with verdict == flag_for_rejection."""
+    return [c for c in payload["companies"] if c.get("verdict") == REJECTION_VERDICT]
+
+
+def run_apply(*, input_path: Path, apply: bool) -> RejectSummary:
+    """Validate and optionally apply rejections."""
+    payload = _load_payload(input_path)
+    summary = RejectSummary(input_path=str(input_path), apply=apply)
+    validation_errors = _validate_payload(payload)
+    if validation_errors:
+        summary.errors.extend(validation_errors)
+        return summary
+
+    all_companies = payload["companies"]
+    candidates = select_rejection_candidates(payload)
+    summary.candidates_seen = len(candidates)
+    summary.skipped_non_rejection = len(all_companies) - len(candidates)
+
+    if apply and not _op_env_is_resolved():
+        summary.errors.append(
+            "live apply requires resolved SUPABASE_DB_URL; run via op run with .env.local"
+        )
+        return summary
+
+    if not apply:
+        summary.rejected_ids = [str(c["id"]) for c in candidates]
+        return summary
+
+    with supabase_db.connection() as conn:
+        supabase_db.apply_schema(conn)
+        for company in candidates:
+            company_id = str(company["id"])
+            supabase_db.set_company_status(conn, company_id, "rejected")
+            supabase_db.insert_ingest_event(
+                conn,
+                source_slug=ADMIN_SOURCE,
+                kind="rejection_apply",
+                payload={
+                    "company_id": company_id,
+                    "name": company.get("name"),
+                    "notes": company.get("notes"),
+                    "evidence_urls": company.get("evidence_urls", []),
+                    "applied_at": datetime.now(UTC).isoformat(),
+                },
+            )
+            summary.rejected += 1
+            summary.rejected_ids.append(company_id)
+        conn.commit()
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input_path", type=Path)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Set discovery_status='rejected' for each candidate. Default is dry-run.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    configure_logging()
+    args = parse_args(argv)
+    summary = run_apply(input_path=args.input_path, apply=args.apply)
+    print(json.dumps(asdict(summary), indent=2, sort_keys=True))
+    if summary.errors:
+        for error in summary.errors:
+            LOGGER.error(error)
+        return 1
+    if not args.apply:
+        LOGGER.info("dry run only; rerun with --apply after review")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_apply_company_rejections.py
+++ b/tests/test_apply_company_rejections.py
@@ -1,0 +1,131 @@
+"""Tests for company rejection application."""
+
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import apply_company_rejections as apply_rejections  # noqa: E402
+
+
+class FakeConn:
+    """Minimal connection stub for rejection tests."""
+
+    def __init__(self) -> None:
+        self.commits = 0
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+def _write_payload(path: Path, *, companies: list[dict[str, Any]]) -> None:
+    path.write_text(json.dumps({"companies": companies}), encoding="utf-8")
+
+
+def test_dry_run_counts_only_rejection_verdicts(tmp_path: Path) -> None:
+    path = tmp_path / "flags.json"
+    _write_payload(
+        path,
+        companies=[
+            {"id": "a", "name": "RejectMe", "verdict": "flag_for_rejection"},
+            {"id": "b", "name": "ReviewMe", "verdict": "flag_for_review"},
+            {"id": "c", "name": "AlsoReject", "verdict": "flag_for_rejection"},
+        ],
+    )
+
+    summary = apply_rejections.run_apply(input_path=path, apply=False)
+
+    assert summary.errors == []
+    assert summary.candidates_seen == 2
+    assert summary.skipped_non_rejection == 1
+    assert summary.rejected == 0
+    assert summary.rejected_ids == ["a", "c"]
+
+
+def test_apply_refuses_unresolved_op_reference(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "flags.json"
+    _write_payload(
+        path,
+        companies=[{"id": "a", "name": "RejectMe", "verdict": "flag_for_rejection"}],
+    )
+    monkeypatch.setenv("SUPABASE_DB_URL", "op://vault/item/field")
+
+    summary = apply_rejections.run_apply(input_path=path, apply=True)
+
+    assert summary.rejected == 0
+    assert summary.errors == [
+        "live apply requires resolved SUPABASE_DB_URL; run via op run with .env.local"
+    ]
+
+
+def test_apply_writes_rejections_and_audit_events(tmp_path: Path, monkeypatch) -> None:
+    path = tmp_path / "flags.json"
+    _write_payload(
+        path,
+        companies=[
+            {
+                "id": "company-1",
+                "name": "RejectMe",
+                "verdict": "flag_for_rejection",
+                "notes": "Defunct since 2024.",
+                "evidence_urls": ["https://example.com/postmortem"],
+            },
+            {
+                "id": "company-2",
+                "name": "KeepMe",
+                "verdict": "flag_for_review",
+            },
+        ],
+    )
+    fake_conn = FakeConn()
+    status_calls: list[tuple[str, str]] = []
+    event_calls: list[dict[str, Any]] = []
+    monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://example")
+
+    @contextmanager
+    def fake_connection():
+        yield fake_conn
+
+    def fake_set_status(conn, company_id, status):
+        status_calls.append((company_id, status))
+
+    def fake_insert_ingest(conn, **kwargs):
+        event_calls.append(kwargs)
+        return "fake-event-id"
+
+    monkeypatch.setattr(apply_rejections.supabase_db, "connection", fake_connection)
+    monkeypatch.setattr(apply_rejections.supabase_db, "apply_schema", lambda conn: None)
+    monkeypatch.setattr(apply_rejections.supabase_db, "set_company_status", fake_set_status)
+    monkeypatch.setattr(apply_rejections.supabase_db, "insert_ingest_event", fake_insert_ingest)
+
+    summary = apply_rejections.run_apply(input_path=path, apply=True)
+
+    assert summary.errors == []
+    assert summary.rejected == 1
+    assert summary.skipped_non_rejection == 1
+    assert status_calls == [("company-1", "rejected")]
+    assert fake_conn.commits == 1
+    assert len(event_calls) == 1
+    assert event_calls[0]["source_slug"] == apply_rejections.ADMIN_SOURCE
+    assert event_calls[0]["kind"] == "rejection_apply"
+    assert event_calls[0]["payload"]["company_id"] == "company-1"
+    assert event_calls[0]["payload"]["notes"] == "Defunct since 2024."
+
+
+def test_payload_rejects_missing_id(tmp_path: Path) -> None:
+    path = tmp_path / "flags.json"
+    _write_payload(
+        path,
+        companies=[{"name": "NoId", "verdict": "flag_for_rejection"}],
+    )
+
+    summary = apply_rejections.run_apply(input_path=path, apply=False)
+
+    assert summary.errors
+    assert "missing id" in summary.errors[0]


### PR DESCRIPTION
## Summary

What this PR does in one or two sentences.

## Why

What problem does it solve? What does it enable?

## Changes

- ...
- ...
- ...

## Test plan

- [ ] `pytest -q` passes
- [ ] `ruff check .` passes
- [ ] `black --check .` passes
- [ ] Manual smoke check (describe)
- [ ] `PROJECT_PROGRESS.md` updated *if* this is a milestone (closes Now/Next issue, ships public feature, breaks something). Otherwise leave alone.

## Multi-agent coordination

- [ ] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [ ] I am the assignee on the linked issue
- [ ] Branch is named `<tool>/<issue-number>-<slug>`
- [ ] Rebased on latest `main` (no merge conflicts with other in-flight PRs)

## Screenshots

(If this changes the dashboard.)

## Related issues

Closes #

Closes #91

## What this PR does

Adds `scripts/apply_company_rejections.py` and uses it to reject 16 verified
companies that the deep-research verification pass flagged as defunct,
non-ANZ, or non-AI.

## Apply summary

- Candidates rejected: 16
- Skipped (review verdict, not rejection): 7
- Audit rows in `ingest_events` (source_slug=`verification_rejection_apply`): 16
- Verified count went from 66 to 50

## Spot-check

Confirmed against live Supabase that 5 of the 16 now show
`discovery_status = 'rejected'`: Hevi, Maxwell Plus, Pearler, Soul Machines,
Sourcegraph (origins).

## Categories of rejection

- Defunct: Maxwell Plus, Soul Machines, Cipherise
- Non-ANZ HQ: Hevi (TR), Augmenta (CA), Composite (US), NodeOps (IN/US),
  Sourcegraph (US), Volt (US), Chronos (NO), Skedulo (US)
- Not actually AI / wrong identity: Algenie (biotech), Pearler (finance),
  Spaceship (super), Syenta (semiconductor), Alloy (unverifiable)

## Tests

Four fixture-driven tests (FakeConn, no live DB) covering dry-run counts,
the unresolved-secret guard, the live apply path with audit, and the
missing-id validation. Full `pytest -q` and `ruff check .` pass clean.

## Reversal

Each rejection flips `discovery_status` only. Reversible by setting back to
`verified`.
