### PR TITLE
[#97] [feature] apply 4-company re-run verification updates to live Supabase

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -15,6 +15,18 @@ contact details out of this file. Routine fixes belong in PR bodies.
 
 ## Recent Milestones
 
+### 2026-04-30: Re-Run Verification For Four Missed Companies
+
+- Filled coverage gap from the original deep-research pass (the first-listed
+  company in four cohorts was dropped from Gemini's JSON output despite being
+  discussed in the prose).
+- Wrote substantive updates for AutoGrab (Melbourne, Series B+, 91 staff),
+  Advanced Navigation (headcount 188), and Cortical Labs (Melbourne, Series A,
+  35 staff).
+- Atlassian's re-verification flagged it for rejection on a strict AI-first
+  reading; held that decision for a human policy call (mirrors the precedent
+  set for Canva, kept in the review pile rather than rejected).
+
 ### 2026-04-30: Dropped Founders From Public Profile
 
 - Removed the founders field from the public companies API and from the


### PR DESCRIPTION
## Summary

What this PR does in one or two sentences.

## Why

What problem does it solve? What does it enable?

## Changes

- ...
- ...
- ...

## Test plan

- [ ] `pytest -q` passes
- [ ] `ruff check .` passes
- [ ] `black --check .` passes
- [ ] Manual smoke check (describe)
- [ ] `PROJECT_PROGRESS.md` updated *if* this is a milestone (closes Now/Next issue, ships public feature, breaks something). Otherwise leave alone.

## Multi-agent coordination

- [ ] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [ ] I am the assignee on the linked issue
- [ ] Branch is named `<tool>/<issue-number>-<slug>`
- [ ] Rebased on latest `main` (no merge conflicts with other in-flight PRs)

## Screenshots

(If this changes the dashboard.)

## Related issues

Closes #

Closes #97

## What this PR does

Records the 4-company re-run verification apply as a milestone. The data
write happened operationally via `scripts/apply_company_profile_updates.py --apply`
against the regenerated apply JSON. This commit only updates
`PROJECT_PROGRESS.md` to reflect that.

## Apply summary

- Companies in apply payload: 42 (39 idempotent re-applies, 3 first-time)
- Field-writes:                510 (incl. profile_verified_at stamps)
- Errors:                       0
- Source artifact:             `data/verification/apply_20260430T002200Z.json` (gitignored)

## Spot-check

Confirmed against live Supabase:

- AutoGrab (Melbourne, Series B+, 91 staff, US$64.4M raised, AUD 230M valuation)
- Advanced Navigation (headcount 188, fresh verified_at stamp)
- Cortical Labs (Melbourne, Series A, 35 staff)

## Held back: Atlassian rejection

The re-run flagged Atlassian for rejection on a strict 'AI-first' interpretation:
Rovo and Atlassian Intelligence are AI features, but the company itself is a
mature collaboration software vendor. This conflicts with the precedent we
set for Canva (similar profile - kept in the review pile, not rejected). The
rejection script was NOT run for this round. Atlassian remains `verified`.
A maintainer policy call is needed before any rejection.

## Followups

- Decide Atlassian's verdict (reject like the model recommended, or treat as flag_for_review like Canva).
- Triage the 7 review-flagged companies (Mable, PaperLab, Vxt, SafetyCulture, Canva, Leonardo.Ai, Vixia) in /Admin.
- Parser-hardening follow-up: normalise string "high"/"medium"/"low" `profile_confidence` values to floats so manual JSON edits aren't needed each apply.
