### PR TITLE
[#101] [feature] commit deep-research verification scripts and prompt template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ htmlcov/
 
 # Local data caches (Supabase is the source of truth)
 data/local/
+data/verification/
 docs/data-audits/*
 !docs/data-audits/README.md
 *.sqlite

--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -15,6 +15,18 @@ contact details out of this file. Routine fixes belong in PR bodies.
 
 ## Recent Milestones
 
+### 2026-04-30: Verification Tooling Committed
+
+- Added the deep-research verification toolkit to the repo so future re-runs
+  do not depend on local stash state: a sector-by-sector prompt template,
+  a per-group prompt generator, a response parser tolerant of Gemini and
+  ChatGPT output styles, and a verified-companies dump helper.
+- Hardened the parser so string `profile_confidence` labels (e.g. `"high"`,
+  `"medium"`, `"low"`) are normalised to floats automatically. Removes the
+  manual JSON-edit step that has been needed each apply cycle.
+- Added fixture-driven tests for both the generator and the parser; full
+  `pytest`, `ruff` and `black` pass.
+
 ### 2026-04-30: Re-Run Verification For Four Missed Companies
 
 - Filled coverage gap from the original deep-research pass (the first-listed

--- a/prompts/verify_sector.md
+++ b/prompts/verify_sector.md
@@ -1,0 +1,134 @@
+# Verify ANZ AI startup records — sector: {{SECTOR_LABEL}}
+
+You are verifying records in the AI Sector Watch database, a public ecosystem map of Australian and New Zealand AI startups (https://aimap.cliftonfamily.co). For each company below, confirm or correct each field against authoritative web sources, then return a single JSON array as specified at the bottom of this prompt.
+
+## Sector context
+
+- Sector tag: `{{SECTOR_TAG}}`
+- Sector label: {{SECTOR_LABEL}}
+- Group: {{SECTOR_GROUP}}
+
+In-scope companies are: headquartered in Australia or New Zealand, AI-focused (AI is core to the product, not a buzzword), and currently operating. Out-of-scope companies should be returned with verdict `flag_for_rejection`.
+
+## Companies to verify ({{COMPANY_COUNT}})
+
+{{COMPANIES_BLOCK}}
+
+## Fields to verify
+
+For each company, check every field against authoritative public sources. Prefer in this order: the company's own site (about, team, press), official press releases, established business press (AFR, SmartCompany, ITNews, Crunchbase News, NZ Herald, Stuff), and Crunchbase/Pitchbook profiles where available.
+
+### Free-form fields
+
+- `website` (URL of the canonical product site, not a redirect or social profile)
+- `country` (must be `AU` or `NZ`; flag for rejection if neither)
+- `city` (must be one of the supported cities below, else flag for review)
+- `summary` (one paragraph, max 80 words, no em dashes — use a colon, comma, or " - " instead)
+- `founded_year` (integer)
+- `founders` (array of full names; only people who founded the company)
+- `total_raised_usd` (cumulative external funding in USD; convert from raw currency)
+- `total_raised_currency_raw` (e.g. `"AUD 12M"` as reported)
+- `total_raised_as_of` (ISO date the figure was reported, e.g. `2024-11-12`)
+- `total_raised_source_url` (URL of the report)
+- `valuation_usd`, `valuation_currency_raw`, `valuation_as_of`, `valuation_source_url` (same shape as funding)
+- `headcount_estimate` (integer, single number) OR `headcount_min` and `headcount_max` (when only a range is reported, e.g. LinkedIn band)
+- `headcount_as_of` (ISO date)
+- `headcount_source_url`
+
+### Constrained fields (must use exact values from these lists)
+
+**`sector_tags`** — pick 1 to 4 tags from this list. Most relevant first:
+
+{{SECTOR_ENUM_LIST}}
+
+**`stage`** — pick exactly one:
+
+{{STAGE_ENUM_LIST}}
+
+**`city`** — pick one of these supported ANZ cities, or set to `null` and use `verdict: "flag_for_review"` if the company is in a city not on this list:
+
+{{CITIES_LIST}}
+
+## Hard rules
+
+1. **Cite every changed field.** Add the supporting URL to `evidence_urls`. Funding figures must additionally have `*_source_url` populated and `*_as_of` (the date the figure was reported, not today).
+2. **No guessing.** If a fact cannot be verified from a source, omit it from `updates` (do not include the key).
+3. **No em dashes** anywhere in `summary`. Replace with a colon, comma, or " - ".
+4. **Confirm vs update.** If every current field already matches the public record, return `verdict: "confirm"` with empty `updates`. If anything changed, return `verdict: "update"` with only the changed fields in `updates`.
+5. **Flag for rejection** (`verdict: "flag_for_rejection"`) when: company appears defunct, has been acquired and absorbed, is not actually AI-focused, is not headquartered in AU or NZ, or its identity is genuinely ambiguous from public sources. Do not auto-reject — this is a flag for a human reviewer.
+6. **Flag for review** (`verdict: "flag_for_review"`) when you have material doubt that a human should resolve (e.g. the company moved cities to one not on the supported list, identity matches but website now points elsewhere, conflicting funding figures across sources). Include the issue in `notes`.
+7. **Confidence** is your honest 0.0–1.0 score for the verification overall, not for any single field.
+8. **Profile sources.** When you provide updates, populate `profile_sources` (in `updates`) with the same authoritative URLs you cited.
+
+## Output schema
+
+Return a single JSON array. One object per company in the order they appear above. Wrap the array in a fenced ` ```json ` block so it parses cleanly.
+
+```json
+[
+  {
+    "id": "<company uuid, copied verbatim from the input>",
+    "name": "<company name, for human reference>",
+    "verdict": "confirm" | "update" | "flag_for_review" | "flag_for_rejection",
+    "updates": {
+      "field_name": "new value (only fields that changed; omit unchanged)"
+    },
+    "evidence_urls": ["https://...", "https://..."],
+    "confidence": 0.92,
+    "notes": "One paragraph for the human reviewer. Mention anything surprising, conflicting, or worth a follow-up."
+  }
+]
+```
+
+## Worked example
+
+Suppose the input contained this company:
+
+```
+- id: 00000000-0000-0000-0000-000000000abc
+  name: ExampleAI
+  country: AU
+  city: Sydney
+  website: https://example.ai
+  sector_tags: [vertical_legal]
+  stage: seed
+  founded_year: 2021
+  summary: Legal AI assistant for ANZ law firms.
+  founders: [Jane Doe]
+  total_raised_usd: 2000000
+  headcount_estimate: 12
+```
+
+After verification you discover ExampleAI raised a Series A of AUD 18M in Oct 2025 (per AFR), now has ~35 staff (per LinkedIn), and the website is unchanged. The output entry is:
+
+```json
+{
+  "id": "00000000-0000-0000-0000-000000000abc",
+  "name": "ExampleAI",
+  "verdict": "update",
+  "updates": {
+    "stage": "series_a",
+    "total_raised_usd": 14000000,
+    "total_raised_currency_raw": "AUD 20M cumulative",
+    "total_raised_as_of": "2025-10-14",
+    "total_raised_source_url": "https://www.afr.com/...",
+    "headcount_estimate": 35,
+    "headcount_as_of": "2026-04-01",
+    "headcount_source_url": "https://www.linkedin.com/company/example-ai/",
+    "profile_sources": [
+      "https://www.afr.com/...",
+      "https://www.linkedin.com/company/example-ai/"
+    ]
+  },
+  "evidence_urls": [
+    "https://www.afr.com/...",
+    "https://www.linkedin.com/company/example-ai/"
+  ],
+  "confidence": 0.9,
+  "notes": "Series A funding well documented. Headcount from LinkedIn band 26-50, took midpoint."
+}
+```
+
+## Begin verification
+
+Work through the {{COMPANY_COUNT}} companies above in order. Return one JSON array, no preamble, no trailing commentary outside the fenced JSON block.

--- a/scripts/dump_verified_companies.py
+++ b/scripts/dump_verified_companies.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Dump every verified company to a local JSON file for offline inspection.
+
+Used by the verification-prompt curation flow: an agent reads the dumped
+JSON, decides groupings, and emits paste-ready prompts. Dump is read-only.
+
+Usage:
+    op run --env-file=.env.local -- python scripts/dump_verified_companies.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from ai_sector_watch.config import configure_logging  # noqa: E402
+from ai_sector_watch.storage import supabase_db  # noqa: E402
+
+LOGGER = logging.getLogger("dump_verified_companies")
+DEFAULT_OUTPUT_PATH = REPO_ROOT / "data" / "verification" / "companies_verified.json"
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    return str(value)
+
+
+def main() -> int:
+    """Read all verified companies from Supabase, write to DEFAULT_OUTPUT_PATH."""
+    configure_logging()
+    with supabase_db.connection() as conn:
+        rows = supabase_db.list_companies(conn, statuses=("verified",))
+    DEFAULT_OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    DEFAULT_OUTPUT_PATH.write_text(
+        json.dumps(rows, indent=2, default=_json_default, sort_keys=False),
+        encoding="utf-8",
+    )
+    LOGGER.info("wrote %d verified companies to %s", len(rows), DEFAULT_OUTPUT_PATH)
+    print(json.dumps({"count": len(rows), "path": str(DEFAULT_OUTPUT_PATH)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_verification_prompts.py
+++ b/scripts/generate_verification_prompts.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Generate per-sector deep-research verification prompts.
+
+Reads verified companies from Supabase, buckets them by sector, and emits one
+Markdown prompt per sector (with parts when a sector exceeds the limit). Each
+prompt is designed to be run in Gemini Deep Research, ChatGPT Deep Research,
+or Perplexity Pro - or driven programmatically by `run_verification_prompts.py`.
+
+Usage:
+    op run --env-file=.env.local -- python scripts/generate_verification_prompts.py --write
+    op run --env-file=.env.local -- python scripts/generate_verification_prompts.py --sector vertical_legal --write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from ai_sector_watch.config import configure_logging  # noqa: E402
+from ai_sector_watch.discovery.geocoder import known_cities  # noqa: E402
+from ai_sector_watch.discovery.taxonomy import (  # noqa: E402
+    SECTOR_GROUPS,
+    SECTORS,
+    STAGES,
+    get_sector,
+)
+from ai_sector_watch.storage import supabase_db  # noqa: E402
+
+LOGGER = logging.getLogger("generate_verification_prompts")
+
+PROMPT_TEMPLATE_PATH = REPO_ROOT / "prompts" / "verify_sector.md"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "data" / "verification"
+DEFAULT_LIMIT_PER_PROMPT = 25
+
+SECTOR_DESCRIPTIONS: dict[str, str] = {
+    "foundation_models": "Companies training or fine-tuning their own large language, vision, or multimodal models.",
+    "ai_infrastructure": "Compute, model serving, data pipelines, fine-tuning platforms, and other AI substrate.",
+    "vector_search_and_retrieval": "Vector databases, embedding pipelines, hybrid search, and retrieval engines.",
+    "evals_and_observability": "Evaluation harnesses, prompt and trace observability, model monitoring, and safety testing.",
+    "vertical_legal": "AI applied to legal workflows: contract review, e-discovery, litigation, in-house automation.",
+    "vertical_healthcare": "AI applied to clinical, diagnostic, medical-imaging, drug-discovery, or digital-health workflows.",
+    "vertical_finance": "AI applied to trading, underwriting, fraud, accounting, banking, or wealth.",
+    "vertical_sales_marketing": "AI applied to sales prospecting, marketing copy, ad creative, CRM enrichment, or revenue ops.",
+    "vertical_security": "AI applied to cyber security: threat detection, fraud, identity, SOC automation.",
+    "robotics_industrial": "Industrial robotics: manufacturing, logistics, mining, agriculture, construction.",
+    "robotics_autonomous_vehicles": "Autonomous ground or aerial vehicles, ADAS, or self-driving stacks.",
+    "robotics_household": "Consumer or service robotics for the home or hospitality.",
+    "ai_for_science_biology": "AI for biological discovery: protein, genomics, biotech R&D, lab automation.",
+    "ai_for_science_chemistry": "AI for chemistry: materials simulation, reaction prediction, molecular design.",
+    "ai_for_science_materials": "AI for materials science: alloys, composites, batteries, semiconductors.",
+    "ai_for_climate_energy": "AI applied to climate, decarbonisation, energy markets, grid operations, or sustainability.",
+    "defence_and_dual_use": "Defence and dual-use AI: ISR, autonomy, sensing, sovereign capability.",
+    "edge_and_on_device": "AI that runs at the edge or on-device: embedded models, optimised inference, hardware-aware tooling.",
+    "developer_tools": "Tools for developers building AI products: SDKs, agents-as-code, prompt tooling, IDE assistants.",
+    "agents_and_orchestration": "Agentic systems, workflow orchestration, planners, and multi-step automation.",
+    "creative_and_media": "Generative creative: text, image, video, audio, music, design, and media production.",
+}
+
+# Fields surfaced in the prompt's company block (the "current record").
+PROMPT_VISIBLE_FIELDS: tuple[str, ...] = (
+    "country",
+    "city",
+    "website",
+    "sector_tags",
+    "stage",
+    "founded_year",
+    "summary",
+    "founders",
+    "total_raised_usd",
+    "total_raised_currency_raw",
+    "total_raised_as_of",
+    "total_raised_source_url",
+    "valuation_usd",
+    "valuation_currency_raw",
+    "valuation_as_of",
+    "valuation_source_url",
+    "headcount_estimate",
+    "headcount_min",
+    "headcount_max",
+    "headcount_as_of",
+    "headcount_source_url",
+    "profile_confidence",
+    "profile_verified_at",
+)
+
+
+@dataclass
+class GenerateSummary:
+    """Operator-facing summary for a generator run."""
+
+    output_dir: str
+    write: bool
+    sectors_seen: int = 0
+    prompts_written: int = 0
+    companies_in_prompts: int = 0
+    skipped_sectors: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def _slugify(name: str) -> str:
+    name = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return name or "company"
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, Decimal):
+        # Drop trailing zeros for cleaner display.
+        return format(value.normalize(), "f")
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, list | tuple):
+        if not value:
+            return "[]"
+        return "[" + ", ".join(_format_value(v) for v in value) + "]"
+    text = str(value)
+    if "\n" in text:
+        text = " ".join(text.split())
+    return text
+
+
+def _company_yaml_block(company: dict[str, Any]) -> str:
+    """Render one company's current record as a yaml-ish block for the prompt."""
+    lines = [
+        f"- id: {company['id']}",
+        f"  name: {_format_value(company.get('name'))}",
+    ]
+    for field_name in PROMPT_VISIBLE_FIELDS:
+        if field_name not in company:
+            continue
+        value = company.get(field_name)
+        if value is None or value == [] or value == "":
+            # Show null explicitly so the model knows the field is empty.
+            lines.append(f"  {field_name}: null")
+            continue
+        lines.append(f"  {field_name}: {_format_value(value)}")
+    return "\n".join(lines)
+
+
+def _enum_list(items: list[tuple[str, str]]) -> str:
+    return "\n".join(f"- `{tag}` - {label}" for tag, label in items)
+
+
+def _sector_enum_lines() -> list[tuple[str, str]]:
+    return [(s.tag, s.label) for s in SECTORS]
+
+
+def _stage_enum_lines() -> list[tuple[str, str]]:
+    pretty = {
+        "pre_seed": "Pre-seed (idea or angel round)",
+        "seed": "Seed (institutional seed round)",
+        "series_a": "Series A",
+        "series_b_plus": "Series B or later",
+        "mature": "Mature (revenue-driven, post-Series-C, public, or bootstrapped at scale)",
+    }
+    return [(stage, pretty.get(stage, stage)) for stage in STAGES]
+
+
+def _cities_block() -> str:
+    return ", ".join(known_cities())
+
+
+def render_prompt(
+    *,
+    template: str,
+    sector_tag: str,
+    sector_label: str,
+    sector_group: str,
+    sector_description: str,
+    companies: list[dict[str, Any]],
+) -> str:
+    """Render the prompt for a single sector (or sector-part)."""
+    company_blocks = "\n\n".join(_company_yaml_block(company) for company in companies)
+    replacements = {
+        "{{SECTOR_TAG}}": sector_tag,
+        "{{SECTOR_LABEL}}": sector_label,
+        "{{SECTOR_GROUP}}": sector_group,
+        "{{SECTOR_DESCRIPTION}}": sector_description,
+        "{{COMPANY_COUNT}}": str(len(companies)),
+        "{{COMPANIES_BLOCK}}": company_blocks,
+        "{{SECTOR_ENUM_LIST}}": _enum_list(_sector_enum_lines()),
+        "{{STAGE_ENUM_LIST}}": _enum_list(_stage_enum_lines()),
+        "{{CITIES_LIST}}": _cities_block(),
+    }
+    rendered = template
+    for key, value in replacements.items():
+        rendered = rendered.replace(key, value)
+    return rendered
+
+
+def bucket_by_sector(companies: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Group companies by sector tag. Multi-tag companies appear in each sector."""
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for company in companies:
+        tags = company.get("sector_tags") or []
+        if not tags:
+            buckets.setdefault("untagged", []).append(company)
+            continue
+        for tag in tags:
+            buckets.setdefault(tag, []).append(company)
+    return buckets
+
+
+def bucket_by_group(companies: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Group companies by sector colour group. A multi-group company appears once per group it touches.
+
+    Companies are de-duplicated within a group so they don't appear twice when
+    they have multiple sector tags inside the same group.
+    """
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for company in companies:
+        tags = company.get("sector_tags") or []
+        if not tags:
+            buckets.setdefault("untagged", []).append(company)
+            continue
+        groups_touched: set[str] = set()
+        for tag in tags:
+            sector = get_sector(tag)
+            if sector is None:
+                continue
+            groups_touched.add(sector.group)
+        for group in groups_touched:
+            existing = buckets.setdefault(group, [])
+            if not any(str(c.get("id")) == str(company.get("id")) for c in existing):
+                existing.append(company)
+    return buckets
+
+
+GROUP_LABELS: dict[str, str] = {
+    "infra": "AI infrastructure",
+    "vertical": "Vertical applications",
+    "robotics": "Robotics",
+    "science": "AI for science",
+    "climate": "Climate and energy",
+    "defence": "Defence and dual use",
+    "dev_tools": "Developer tools",
+    "agents": "Agents and orchestration",
+    "creative": "Creative and media",
+}
+
+GROUP_DESCRIPTIONS: dict[str, str] = {
+    "infra": "Core AI infrastructure: foundation model training, model serving, vector search and retrieval, evaluations and observability, and edge or on-device inference.",
+    "vertical": "AI applied to specific industries: legal, healthcare, finance, sales and marketing, security.",
+    "robotics": "Robotics across industrial, autonomous-vehicle, and household categories.",
+    "science": "AI for scientific discovery: biology, chemistry, materials.",
+    "climate": "AI applied to climate, decarbonisation, energy markets, and sustainability.",
+    "defence": "Defence and dual-use AI: ISR, autonomy, sensing, sovereign capability.",
+    "dev_tools": "Tools for developers building AI products: SDKs, agents-as-code, IDE assistants.",
+    "agents": "Agentic systems, workflow orchestration, planners, and multi-step automation.",
+    "creative": "Generative creative across text, image, video, audio, music, design, and media production.",
+}
+
+
+def _split_into_parts(
+    companies: list[dict[str, Any]],
+    *,
+    limit_per_prompt: int,
+) -> list[list[dict[str, Any]]]:
+    if limit_per_prompt <= 0:
+        return [companies]
+    return [companies[i : i + limit_per_prompt] for i in range(0, len(companies), limit_per_prompt)]
+
+
+def _prompt_filename(sector_tag: str, *, part: int, parts_total: int) -> str:
+    if parts_total <= 1:
+        return f"verify_{sector_tag}.md"
+    return f"verify_{sector_tag}_part{part}of{parts_total}.md"
+
+
+def _response_filename(prompt_filename: str) -> str:
+    # `verify_<x>.md` -> `verify_<x>.json`
+    return Path(prompt_filename).with_suffix(".json").name
+
+
+def run_generate(
+    *,
+    output_dir: Path,
+    sector_filter: str | None,
+    limit_per_prompt: int,
+    write: bool,
+    bucket_strategy: str = "per-sector",
+    companies: list[dict[str, Any]] | None = None,
+) -> GenerateSummary:
+    """Build and (optionally) write the verification prompts.
+
+    bucket_strategy:
+        - "per-sector": one prompt per sector tag (~21 prompts).
+        - "per-group": one prompt per sector colour group (9 groups: infra,
+          vertical, robotics, science, climate, defence, dev_tools, agents,
+          creative). Caps prompt count for manual paste workflows.
+    """
+    summary = GenerateSummary(output_dir=str(output_dir), write=write)
+    template = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
+
+    if companies is None:
+        with supabase_db.connection() as conn:
+            companies = supabase_db.list_companies(conn, statuses=("verified",))
+
+    if bucket_strategy == "per-group":
+        buckets = bucket_by_group(companies)
+        bucket_order = list(SECTOR_GROUPS) + sorted(
+            tag for tag in buckets if tag not in SECTOR_GROUPS
+        )
+        bucket_label = GROUP_LABELS
+        bucket_description = GROUP_DESCRIPTIONS
+        bucket_filter = sector_filter
+    else:
+        buckets = bucket_by_sector(companies)
+        bucket_order = [s.tag for s in SECTORS] + sorted(
+            tag for tag in buckets if tag not in {s.tag for s in SECTORS}
+        )
+        bucket_label = {s.tag: s.label for s in SECTORS}
+        bucket_description = SECTOR_DESCRIPTIONS
+        bucket_filter = sector_filter
+    summary.sectors_seen = len(buckets)
+
+    prompts_dir = output_dir / "prompts"
+    if write:
+        prompts_dir.mkdir(parents=True, exist_ok=True)
+
+    index: dict[str, Any] = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "limit_per_prompt": limit_per_prompt,
+        "bucket_strategy": bucket_strategy,
+        "prompts": [],
+    }
+
+    for bucket_key in bucket_order:
+        bucket_companies = buckets.get(bucket_key, [])
+        if bucket_filter and bucket_key != bucket_filter:
+            continue
+        if not bucket_companies:
+            summary.skipped_sectors.append(bucket_key)
+            continue
+
+        bucket_companies.sort(key=lambda c: str(c.get("name") or "").lower())
+        parts = _split_into_parts(bucket_companies, limit_per_prompt=limit_per_prompt)
+        for part_index, part_companies in enumerate(parts, start=1):
+            prompt_filename = _prompt_filename(bucket_key, part=part_index, parts_total=len(parts))
+            response_filename = _response_filename(prompt_filename)
+            label = bucket_label.get(bucket_key, bucket_key)
+            description = bucket_description.get(bucket_key, "")
+            group_for_render = (
+                bucket_key
+                if bucket_strategy == "per-group"
+                else (get_sector(bucket_key).group if get_sector(bucket_key) else "")
+            )
+            rendered = render_prompt(
+                template=template,
+                sector_tag=bucket_key,
+                sector_label=label,
+                sector_group=group_for_render,
+                sector_description=description,
+                companies=part_companies,
+            )
+            summary.companies_in_prompts += len(part_companies)
+            summary.prompts_written += 1
+            index["prompts"].append(
+                {
+                    "bucket": bucket_key,
+                    "label": label,
+                    "part": part_index,
+                    "parts_total": len(parts),
+                    "company_count": len(part_companies),
+                    "prompt_path": f"prompts/{prompt_filename}",
+                    "response_path": f"responses/{response_filename}",
+                    "company_ids": [str(c["id"]) for c in part_companies],
+                }
+            )
+            if write:
+                (prompts_dir / prompt_filename).write_text(rendered, encoding="utf-8")
+
+    if bucket_filter and summary.prompts_written == 0:
+        summary.errors.append(
+            f"bucket filter `{bucket_filter}` matched no verified companies; "
+            f"check against the chosen bucket strategy"
+        )
+
+    if write:
+        (output_dir / "index.json").write_text(
+            json.dumps(index, indent=2, sort_keys=False), encoding="utf-8"
+        )
+
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sector",
+        default=None,
+        help=(
+            "Restrict to one sector tag (per-sector strategy) or one group "
+            "(per-group strategy). Defaults to all."
+        ),
+    )
+    parser.add_argument(
+        "--bucket-strategy",
+        choices=("per-sector", "per-group"),
+        default="per-group",
+        help=(
+            "How to bucket companies across prompts. "
+            "per-group (default) bundles by colour group (~9 prompts). "
+            "per-sector emits one prompt per sector tag (~21 prompts)."
+        ),
+    )
+    parser.add_argument(
+        "--limit-per-prompt",
+        type=int,
+        default=DEFAULT_LIMIT_PER_PROMPT,
+        help="Max companies per prompt; oversized buckets split into part1, part2, ...",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Where to write prompts/, responses/, and index.json.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write prompt files to disk. Default is dry-run.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    configure_logging()
+    args = parse_args(argv)
+    if args.sector is not None:
+        if args.bucket_strategy == "per-sector" and get_sector(args.sector) is None:
+            LOGGER.error("unknown sector tag: %s", args.sector)
+            return 2
+        if args.bucket_strategy == "per-group" and args.sector not in SECTOR_GROUPS:
+            LOGGER.error("unknown sector group: %s", args.sector)
+            return 2
+    if args.limit_per_prompt < 1:
+        LOGGER.error("--limit-per-prompt must be a positive integer")
+        return 2
+
+    summary = run_generate(
+        output_dir=args.output_dir,
+        sector_filter=args.sector,
+        limit_per_prompt=args.limit_per_prompt,
+        write=args.write,
+        bucket_strategy=args.bucket_strategy,
+    )
+    print(json.dumps(asdict(summary), indent=2, sort_keys=True))
+    if summary.errors:
+        for error in summary.errors:
+            LOGGER.error(error)
+        return 1
+    if not args.write:
+        LOGGER.info("dry run only; rerun with --write to emit prompt files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/parse_verification_responses.py
+++ b/scripts/parse_verification_responses.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+"""Parse deep-research verification responses into apply-ready artifacts.
+
+Reads JSON responses produced by Gemini Deep Research / ChatGPT Deep Research
+(saved into `data/verification/responses/`), validates them against the apply
+script's allowed fields, merges per-company verdicts (multi-sector companies
+appear in more than one response), and writes:
+
+  - `apply_<timestamp>.json` for `scripts/apply_company_profile_updates.py`
+  - `flags_<timestamp>.json` for human triage in /Admin
+
+Usage:
+    python scripts/parse_verification_responses.py
+    python scripts/parse_verification_responses.py --input data/verification --write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import apply_company_profile_updates as apply_updates  # noqa: E402
+
+from ai_sector_watch.config import configure_logging  # noqa: E402
+from ai_sector_watch.discovery.geocoder import known_cities  # noqa: E402
+from ai_sector_watch.discovery.taxonomy import SECTOR_TAGS, STAGES  # noqa: E402
+
+LOGGER = logging.getLogger("parse_verification_responses")
+
+DEFAULT_INPUT_DIR = REPO_ROOT / "data" / "verification"
+ALLOWED_FIELDS = apply_updates.ALLOWED_UPDATE_FIELDS
+VALID_VERDICTS = {"confirm", "update", "flag_for_review", "flag_for_rejection"}
+EM_DASH_PATTERN = re.compile(r"\s*[—–]\s*")  # em/en dashes with surrounding whitespace
+ISO_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+JSON_FENCE_PATTERN = re.compile(r"```(?:json)?\s*\n?(.*?)\n?```", re.DOTALL)
+
+# Gemini DR sometimes emits profile_confidence as a string label rather than a
+# float. Map the common labels onto sensible mid-band floats so the apply does
+# not blow up on the numeric column.
+CONFIDENCE_LABEL_MAP: dict[str, float] = {
+    "high": 0.9,
+    "medium": 0.7,
+    "low": 0.4,
+}
+
+
+@dataclass
+class CompanyEntry:
+    """One per-company verdict, validated and ready for downstream use."""
+
+    id: str
+    name: str
+    verdict: str
+    updates: dict[str, Any] = field(default_factory=dict)
+    evidence_urls: list[str] = field(default_factory=list)
+    confidence: float | None = None
+    notes: str = ""
+    source_files: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ParseSummary:
+    """Operator-facing summary for a parser run."""
+
+    input_dir: str
+    write: bool
+    files_seen: int = 0
+    files_failed: list[str] = field(default_factory=list)
+    entries_seen: int = 0
+    by_verdict: dict[str, int] = field(default_factory=dict)
+    conflicts: list[str] = field(default_factory=list)
+    apply_path: str | None = None
+    flags_path: str | None = None
+    errors: list[str] = field(default_factory=list)
+
+
+def _balanced_json_substring(text: str, opener: str, closer: str) -> str | None:
+    """Return the substring from the LAST balanced opener..closer in `text`.
+
+    Walks the text with a depth counter that ignores brackets inside JSON strings
+    (handles escaped quotes). Tries each candidate from the rightmost opener back,
+    returning the first that parses. Returns None if no balanced substring is
+    found.
+    """
+    in_string = False
+    escape = False
+    depth = 0
+    starts: list[int] = []
+    spans: list[tuple[int, int]] = []
+    for i, ch in enumerate(text):
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == opener:
+            if depth == 0:
+                starts.append(i)
+            depth += 1
+        elif ch == closer and depth > 0:
+            depth -= 1
+            if depth == 0 and starts:
+                spans.append((starts[-1], i + 1))
+    # Try the latest balanced span first - DR reports place the answer last.
+    for start, end in reversed(spans):
+        candidate = text[start:end]
+        try:
+            json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        return candidate
+    return None
+
+
+_MARKDOWN_ESCAPE_PATTERN = re.compile(r"\\([_\[\]+\-.()#<>|~!*&])")
+_EMPTY_VALUE_PATTERN = re.compile(r'("\w+"\s*:)\s*([,}\]])')
+
+
+def _repair_markdown_json(text: str) -> str:
+    """Strip common markdown escapes Gemini DR sprinkles inside JSON.
+
+    Gemini Deep Research outputs the answer JSON as plain text (no fences),
+    inside which it markdown-escapes underscores, brackets, plus signs etc.,
+    and emits empty values as `"key":,` instead of `"key": null,`. This
+    function repairs both so json.loads can take it.
+    """
+    repaired = _MARKDOWN_ESCAPE_PATTERN.sub(r"\1", text)
+    # `"key":,` -> `"key": null,` ; `"key":}` -> `"key": null}` ; `"key":]` likewise.
+    repaired = _EMPTY_VALUE_PATTERN.sub(r"\1 null\2", repaired)
+    # Strip trailing whitespace per line (markdown line-break artifacts).
+    repaired = "\n".join(line.rstrip() for line in repaired.splitlines())
+    return repaired
+
+
+def _collect_id_bearing_objects(text: str) -> list[dict[str, Any]]:
+    """Find every balanced {..} in text that parses to a dict with an 'id' key.
+
+    Used when Deep Research emits one JSON object per company instead of a single
+    top-level array.
+    """
+    in_string = False
+    escape = False
+    depth = 0
+    starts: list[int] = []
+    objects: list[dict[str, Any]] = []
+    for i, ch in enumerate(text):
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            if depth == 0:
+                starts.append(i)
+            depth += 1
+        elif ch == "}" and depth > 0:
+            depth -= 1
+            if depth == 0 and starts:
+                start = starts[-1]
+                candidate = text[start : i + 1]
+                try:
+                    parsed = json.loads(candidate)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict) and "id" in parsed:
+                    objects.append(parsed)
+    return objects
+
+
+def _extract_json_array(text: str) -> Any:
+    """Pull the JSON array or object out of a response text blob.
+
+    Strategy, in order:
+      1. The whole text is JSON.
+      2. The LAST fenced ```json (or ```) block whose body parses.
+      3. The LAST balanced [...] in the text whose body parses.
+      4. The LAST balanced {...} in the text whose body parses.
+      5. Repeat 1-4 after repairing markdown-escaped JSON (Gemini DR style).
+
+    Deep-research reports usually include a worked example mid-document and the
+    real answer at the end, so we prefer late occurrences.
+    """
+    # Try repaired text first - Gemini DR almost always needs the repair, and
+    # raw text often contains an empty `[]` from a markdown link that would
+    # short-circuit extraction with a useless empty array.
+    candidates_in_order = [_repair_markdown_json(text), text]
+    last_error: Exception = ValueError("no JSON array or object found in response")
+    best_payload: Any = None
+    seen_text: set[str] = set()
+    for source in candidates_in_order:
+        if source in seen_text:
+            continue
+        seen_text.add(source)
+        stripped = source.strip()
+        try:
+            payload = json.loads(stripped)
+            best_payload = _prefer_richer(best_payload, payload)
+        except json.JSONDecodeError as exc:
+            last_error = exc
+
+        fence_matches = list(JSON_FENCE_PATTERN.finditer(source))
+        for match in reversed(fence_matches):
+            body = match.group(1).strip()
+            try:
+                payload = json.loads(body)
+                best_payload = _prefer_richer(best_payload, payload)
+            except json.JSONDecodeError as exc:
+                last_error = exc
+                continue
+
+        for opener, closer in (("[", "]"), ("{", "}")):
+            candidate = _balanced_json_substring(source, opener, closer)
+            if candidate is not None:
+                try:
+                    payload = json.loads(candidate)
+                    best_payload = _prefer_richer(best_payload, payload)
+                except json.JSONDecodeError as exc:
+                    last_error = exc
+
+        # Multi-object collection - Gemini sometimes emits one JSON per company.
+        objects = _collect_id_bearing_objects(source)
+        if objects:
+            best_payload = _prefer_richer(best_payload, objects)
+
+    if best_payload is None:
+        raise ValueError(f"no JSON array or object found in response: {last_error}")
+    return best_payload
+
+
+def _prefer_richer(current: Any, candidate: Any) -> Any:
+    """Prefer the payload that looks like the real verification answer.
+
+    Heuristics:
+      - A list with company-shaped dicts (have an "id" key) wins.
+      - Among lists, more entries with "id" wins.
+      - A non-empty list beats an empty list or a non-list.
+      - A dict with company shape beats a non-company-shaped value.
+    """
+
+    def score(payload: Any) -> tuple[int, int, int]:
+        if isinstance(payload, list):
+            with_id = sum(1 for item in payload if isinstance(item, dict) and "id" in item)
+            return (2 if with_id else (1 if payload else 0), with_id, len(payload))
+        if isinstance(payload, dict):
+            return (2 if "id" in payload else 1, 1 if "id" in payload else 0, 1)
+        return (0, 0, 0)
+
+    if current is None:
+        return candidate
+    return candidate if score(candidate) > score(current) else current
+
+
+def _load_response_file(path: Path) -> list[dict[str, Any]]:
+    """Load one response file and return a list of company entries."""
+    raw = path.read_text(encoding="utf-8")
+    if path.suffix == ".json":
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            payload = _extract_json_array(raw)
+    else:
+        payload = _extract_json_array(raw)
+    if isinstance(payload, dict):
+        # Permit either {"companies": [...]} or a single company object.
+        if "companies" in payload and isinstance(payload["companies"], list):
+            return payload["companies"]
+        return [payload]
+    if not isinstance(payload, list):
+        raise ValueError("response payload must be a list of company entries")
+    return payload
+
+
+def _normalize_flat_schema(entry: dict[str, Any]) -> dict[str, Any]:
+    """Convert a flat-schema entry to the {verdict, updates} shape.
+
+    Some Gemini outputs emit the full company record at the top level (with
+    every field directly on the entry, no nested `updates`). Promote any
+    ALLOWED_FIELDS values found at top level into `updates` and default the
+    verdict to `update`.
+    """
+    if entry.get("verdict") in VALID_VERDICTS or "updates" in entry:
+        return entry
+    flat_updates = {k: v for k, v in entry.items() if k in ALLOWED_FIELDS and v is not None}
+    if not flat_updates:
+        return entry
+    promoted = {k: v for k, v in entry.items() if k not in ALLOWED_FIELDS}
+    promoted["verdict"] = "update"
+    promoted["updates"] = flat_updates
+    return promoted
+
+
+def _validate_entry(entry: dict[str, Any]) -> tuple[CompanyEntry | None, list[str]]:
+    """Validate one entry. Returns the parsed entry plus per-entry errors."""
+    entry = _normalize_flat_schema(entry)
+    errors: list[str] = []
+    company_id = entry.get("id")
+    name = str(entry.get("name") or "")
+    if not company_id or not isinstance(company_id, str):
+        return None, [f"entry missing id (name={name!r})"]
+    label = f"{name} ({company_id})"
+    verdict = entry.get("verdict")
+    if verdict not in VALID_VERDICTS:
+        errors.append(f"{label}: invalid verdict {verdict!r}")
+        verdict = "flag_for_review"
+
+    updates_raw = entry.get("updates") or {}
+    if not isinstance(updates_raw, dict):
+        errors.append(f"{label}: updates must be an object, got {type(updates_raw).__name__}")
+        updates_raw = {}
+
+    updates: dict[str, Any] = {}
+    for key, value in updates_raw.items():
+        if key not in ALLOWED_FIELDS:
+            errors.append(f"{label}: unsupported field {key!r}")
+            continue
+        if value is None:
+            continue
+        if key == "summary" and isinstance(value, str) and EM_DASH_PATTERN.search(value):
+            errors.append(
+                f"{label}: summary contains em/en dash; replace with colon, comma, or ' - '"
+            )
+            value = EM_DASH_PATTERN.sub(" - ", value)
+        if key == "stage" and value not in STAGES:
+            errors.append(f"{label}: invalid stage {value!r}")
+            continue
+        if key == "city" and value not in known_cities():
+            errors.append(f"{label}: city {value!r} not in supported list; flagging")
+            verdict = "flag_for_review"
+            continue
+        if key == "sector_tags":
+            if not isinstance(value, list) or not value:
+                errors.append(f"{label}: sector_tags must be a non-empty list")
+                continue
+            unknown = [tag for tag in value if tag not in SECTOR_TAGS]
+            if unknown:
+                errors.append(f"{label}: unknown sector tags {unknown}")
+                continue
+            if len(value) > 4:
+                errors.append(f"{label}: sector_tags exceeds 4 entries; truncating")
+                value = value[:4]
+        if key.endswith("_as_of") and isinstance(value, str) and not ISO_DATE_PATTERN.match(value):
+            errors.append(f"{label}: {key} must be ISO YYYY-MM-DD, got {value!r}")
+            continue
+        if key == "profile_confidence" and isinstance(value, str):
+            mapped = CONFIDENCE_LABEL_MAP.get(value.strip().lower())
+            if mapped is None:
+                errors.append(
+                    f"{label}: profile_confidence label {value!r} not recognised; dropping"
+                )
+                continue
+            errors.append(f"{label}: profile_confidence {value!r} normalised to {mapped}")
+            value = mapped
+        updates[key] = value
+
+    evidence_urls = entry.get("evidence_urls") or []
+    if not isinstance(evidence_urls, list):
+        errors.append(f"{label}: evidence_urls must be a list")
+        evidence_urls = []
+
+    if verdict == "update" and updates and not evidence_urls:
+        errors.append(f"{label}: verdict=update requires at least one evidence_urls entry")
+
+    confidence = entry.get("confidence")
+    if confidence is not None:
+        try:
+            confidence = float(confidence)
+            if not 0.0 <= confidence <= 1.0:
+                errors.append(f"{label}: confidence {confidence} outside [0, 1]")
+                confidence = max(0.0, min(1.0, confidence))
+        except (TypeError, ValueError):
+            errors.append(f"{label}: confidence not numeric")
+            confidence = None
+
+    parsed = CompanyEntry(
+        id=str(company_id),
+        name=name,
+        verdict=verdict,
+        updates=updates,
+        evidence_urls=[str(u) for u in evidence_urls],
+        confidence=confidence,
+        notes=str(entry.get("notes") or ""),
+    )
+    return parsed, errors
+
+
+def _merge_entries(entries: list[CompanyEntry]) -> tuple[CompanyEntry, list[str]]:
+    """Merge multiple verdicts for the same company id. Returns merged entry + conflicts."""
+    if len(entries) == 1:
+        return entries[0], []
+    # Verdict precedence: rejection > review > update > confirm.
+    precedence = {
+        "flag_for_rejection": 3,
+        "flag_for_review": 2,
+        "update": 1,
+        "confirm": 0,
+    }
+    chosen = max(entries, key=lambda e: precedence.get(e.verdict, 0))
+    merged_updates: dict[str, Any] = {}
+    conflicts: list[str] = []
+    for entry in entries:
+        for key, value in entry.updates.items():
+            if key in merged_updates and merged_updates[key] != value:
+                conflicts.append(
+                    f"{entry.id} ({entry.name}): conflicting {key} across responses "
+                    f"({merged_updates[key]!r} vs {value!r}); flagging for review"
+                )
+            else:
+                merged_updates[key] = value
+    if conflicts:
+        chosen = CompanyEntry(
+            id=chosen.id,
+            name=chosen.name,
+            verdict="flag_for_review",
+            updates={},  # do not auto-apply when responses conflict
+            evidence_urls=sorted({u for e in entries for u in e.evidence_urls}),
+            confidence=chosen.confidence,
+            notes=(chosen.notes + "\n\n" + "\n".join(conflicts)).strip(),
+            source_files=sorted({f for e in entries for f in e.source_files}),
+        )
+        return chosen, conflicts
+    chosen.updates = merged_updates
+    chosen.evidence_urls = sorted({u for e in entries for u in e.evidence_urls})
+    chosen.source_files = sorted({f for e in entries for f in e.source_files})
+    return chosen, []
+
+
+def _emit_apply_payload(entries: list[CompanyEntry]) -> dict[str, Any]:
+    """Shape an apply_*.json payload from update verdicts."""
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "companies": [
+            {
+                "id": entry.id,
+                "name": entry.name,
+                "discovery_status": "verified",
+                "updates": {
+                    **entry.updates,
+                    **(
+                        {"profile_sources": entry.evidence_urls}
+                        if entry.evidence_urls and "profile_sources" not in entry.updates
+                        else {}
+                    ),
+                    **(
+                        {"profile_confidence": entry.confidence}
+                        if entry.confidence is not None
+                        and "profile_confidence" not in entry.updates
+                        else {}
+                    ),
+                },
+                "evidence_urls": entry.evidence_urls,
+                "source_files": entry.source_files,
+            }
+            for entry in entries
+        ],
+    }
+
+
+def _emit_flags_payload(entries: list[CompanyEntry]) -> dict[str, Any]:
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "companies": [
+            {
+                "id": entry.id,
+                "name": entry.name,
+                "verdict": entry.verdict,
+                "notes": entry.notes,
+                "evidence_urls": entry.evidence_urls,
+                "confidence": entry.confidence,
+                "source_files": entry.source_files,
+            }
+            for entry in entries
+        ],
+    }
+
+
+def _emit_confirm_payload(entries: list[CompanyEntry]) -> dict[str, Any]:
+    """Confirms still bump profile_verified_at + profile_confidence; treat as updates."""
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "companies": [
+            {
+                "id": entry.id,
+                "name": entry.name,
+                "discovery_status": "verified",
+                "updates": {
+                    **({"profile_sources": entry.evidence_urls} if entry.evidence_urls else {}),
+                    **(
+                        {"profile_confidence": entry.confidence}
+                        if entry.confidence is not None
+                        else {}
+                    ),
+                },
+                "evidence_urls": entry.evidence_urls,
+                "source_files": entry.source_files,
+            }
+            for entry in entries
+        ],
+    }
+
+
+def run_parse(
+    *,
+    input_dir: Path,
+    write: bool,
+    timestamp: datetime | None = None,
+) -> ParseSummary:
+    """Read all response files under input_dir/responses/, validate, and emit artifacts."""
+    summary = ParseSummary(input_dir=str(input_dir), write=write)
+    responses_dir = input_dir / "responses"
+    if not responses_dir.is_dir():
+        summary.errors.append(f"responses directory not found: {responses_dir}")
+        return summary
+
+    response_files = sorted(p for p in responses_dir.iterdir() if p.is_file())
+    if not response_files:
+        summary.errors.append(f"no response files in {responses_dir}")
+        return summary
+
+    by_id: dict[str, list[CompanyEntry]] = defaultdict(list)
+    for path in response_files:
+        summary.files_seen += 1
+        try:
+            entries = _load_response_file(path)
+        except Exception as exc:  # noqa: BLE001
+            summary.files_failed.append(f"{path.name}: {exc}")
+            LOGGER.error("failed to parse %s: %s", path.name, exc)
+            continue
+        for raw_entry in entries:
+            if not isinstance(raw_entry, dict):
+                summary.files_failed.append(
+                    f"{path.name}: expected object entries, got {type(raw_entry).__name__}"
+                )
+                continue
+            parsed, entry_errors = _validate_entry(raw_entry)
+            for error in entry_errors:
+                LOGGER.warning("%s: %s", path.name, error)
+            if parsed is None:
+                continue
+            parsed.source_files = [path.name]
+            by_id[parsed.id].append(parsed)
+            summary.entries_seen += 1
+
+    merged: list[CompanyEntry] = []
+    for entries in by_id.values():
+        chosen, conflicts = _merge_entries(entries)
+        merged.append(chosen)
+        summary.conflicts.extend(conflicts)
+
+    counts: Counter[str] = Counter(entry.verdict for entry in merged)
+    summary.by_verdict = dict(counts)
+
+    timestamp = timestamp or datetime.now(UTC)
+    stem = timestamp.strftime("%Y%m%dT%H%M%SZ")
+
+    update_entries = [e for e in merged if e.verdict == "update" and e.updates]
+    flag_entries = [e for e in merged if e.verdict in {"flag_for_review", "flag_for_rejection"}]
+    confirm_entries = [e for e in merged if e.verdict == "confirm"]
+
+    apply_payload = _emit_apply_payload(update_entries)
+    flags_payload = _emit_flags_payload(flag_entries)
+    confirm_payload = _emit_confirm_payload(confirm_entries)
+
+    if write:
+        if update_entries:
+            apply_path = input_dir / f"apply_{stem}.json"
+            apply_path.write_text(
+                json.dumps(apply_payload, indent=2, sort_keys=False), encoding="utf-8"
+            )
+            summary.apply_path = str(apply_path)
+        if flag_entries:
+            flags_path = input_dir / f"flags_{stem}.json"
+            flags_path.write_text(
+                json.dumps(flags_payload, indent=2, sort_keys=False), encoding="utf-8"
+            )
+            summary.flags_path = str(flags_path)
+        if confirm_entries:
+            confirm_path = input_dir / f"confirm_{stem}.json"
+            confirm_path.write_text(
+                json.dumps(confirm_payload, indent=2, sort_keys=False), encoding="utf-8"
+            )
+
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=DEFAULT_INPUT_DIR,
+        help="Input dir containing a `responses/` subdir with deep-research JSON files.",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write apply_*.json, flags_*.json, confirm_*.json. Default is dry-run.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    configure_logging()
+    args = parse_args(argv)
+    summary = run_parse(input_dir=args.input, write=args.write)
+    print(json.dumps(asdict(summary), indent=2, sort_keys=True))
+    if summary.errors:
+        for error in summary.errors:
+            LOGGER.error(error)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_verification_prompts.py
+++ b/tests/test_generate_verification_prompts.py
@@ -1,0 +1,142 @@
+"""Tests for the deep-research verification prompt generator."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import generate_verification_prompts as g  # noqa: E402
+
+
+def _company(
+    cid: str, name: str, *, sector_tags: list[str], country: str = "AU"
+) -> dict[str, object]:
+    return {
+        "id": cid,
+        "name": name,
+        "sector_tags": sector_tags,
+        "country": country,
+        "discovery_status": "verified",
+    }
+
+
+def test_bucket_by_sector_keeps_multi_tag_companies_in_each_bucket() -> None:
+    companies = [
+        _company("1", "OnlyLegal", sector_tags=["vertical_legal"]),
+        _company("2", "MultiTag", sector_tags=["vertical_legal", "ai_infrastructure"]),
+    ]
+
+    buckets = g.bucket_by_sector(companies)
+
+    assert {c["name"] for c in buckets["vertical_legal"]} == {"OnlyLegal", "MultiTag"}
+    assert {c["name"] for c in buckets["ai_infrastructure"]} == {"MultiTag"}
+
+
+def test_bucket_by_group_dedupes_within_a_group() -> None:
+    """A company with two sector tags in the SAME group should appear once."""
+    companies = [
+        _company("1", "MultiInGroup", sector_tags=["vertical_legal", "vertical_finance"]),
+        _company("2", "CrossGroup", sector_tags=["vertical_legal", "ai_infrastructure"]),
+    ]
+
+    buckets = g.bucket_by_group(companies)
+
+    vertical_names = [c["name"] for c in buckets["vertical"]]
+    assert vertical_names.count("MultiInGroup") == 1
+    assert vertical_names.count("CrossGroup") == 1
+    assert [c["name"] for c in buckets["infra"]] == ["CrossGroup"]
+
+
+def test_render_prompt_contains_company_record_and_enums() -> None:
+    template = (REPO_ROOT / "prompts" / "verify_sector.md").read_text(encoding="utf-8")
+    companies = [
+        _company("uuid-1", "ExampleCo", sector_tags=["vertical_legal"]),
+    ]
+
+    rendered = g.render_prompt(
+        template=template,
+        sector_tag="vertical_legal",
+        sector_label="Legal",
+        sector_group="vertical",
+        sector_description="Legal AI workflows.",
+        companies=companies,
+    )
+
+    assert "ExampleCo" in rendered
+    assert "uuid-1" in rendered
+    assert "Sydney" in rendered  # cities list rendered
+    assert "vertical_legal" in rendered  # sector enum rendered
+    assert "series_b_plus" in rendered  # stage enum rendered
+    # No leftover placeholder syntax
+    assert "{{" not in rendered and "}}" not in rendered
+
+
+def test_run_generate_per_group_writes_one_prompt_per_group(tmp_path: Path) -> None:
+    companies = [
+        _company("1", "InfraCo", sector_tags=["ai_infrastructure"]),
+        _company("2", "RoboCo", sector_tags=["robotics_industrial"]),
+        _company("3", "MultiCo", sector_tags=["vertical_legal", "ai_infrastructure"]),
+    ]
+
+    summary = g.run_generate(
+        output_dir=tmp_path,
+        sector_filter=None,
+        limit_per_prompt=25,
+        write=True,
+        bucket_strategy="per-group",
+        companies=companies,
+    )
+
+    assert summary.errors == []
+    assert summary.prompts_written == 3  # infra, vertical, robotics
+    written = sorted(p.name for p in (tmp_path / "prompts").iterdir())
+    assert "verify_infra.md" in written
+    assert "verify_vertical.md" in written
+    assert "verify_robotics.md" in written
+
+    index = json.loads((tmp_path / "index.json").read_text(encoding="utf-8"))
+    assert index["bucket_strategy"] == "per-group"
+    infra_prompt = next(p for p in index["prompts"] if p["bucket"] == "infra")
+    assert infra_prompt["company_count"] == 2  # InfraCo + MultiCo
+
+
+def test_run_generate_dry_run_writes_no_files(tmp_path: Path) -> None:
+    companies = [_company("1", "InfraCo", sector_tags=["ai_infrastructure"])]
+
+    summary = g.run_generate(
+        output_dir=tmp_path,
+        sector_filter=None,
+        limit_per_prompt=25,
+        write=False,
+        bucket_strategy="per-group",
+        companies=companies,
+    )
+
+    assert summary.prompts_written == 1
+    assert not (tmp_path / "prompts").exists()
+    assert not (tmp_path / "index.json").exists()
+
+
+def test_run_generate_splits_oversized_buckets(tmp_path: Path) -> None:
+    companies = [_company(str(i), f"Co{i}", sector_tags=["ai_infrastructure"]) for i in range(7)]
+
+    summary = g.run_generate(
+        output_dir=tmp_path,
+        sector_filter="infra",
+        limit_per_prompt=3,
+        write=True,
+        bucket_strategy="per-group",
+        companies=companies,
+    )
+
+    assert summary.prompts_written == 3  # 7 cos / 3 per prompt -> 3 parts (3,3,1)
+    written = sorted(p.name for p in (tmp_path / "prompts").iterdir())
+    assert written == [
+        "verify_infra_part1of3.md",
+        "verify_infra_part2of3.md",
+        "verify_infra_part3of3.md",
+    ]

--- a/tests/test_parse_verification_responses.py
+++ b/tests/test_parse_verification_responses.py
@@ -1,0 +1,241 @@
+"""Tests for the deep-research verification response parser."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import parse_verification_responses as p  # noqa: E402
+
+
+def test_extract_json_array_picks_last_fenced_block() -> None:
+    """Worked-example block without an id should be ignored; final answer wins."""
+    text = """
+# Report
+
+Schema reminder (no id in this demo on purpose):
+
+```json
+{"verdict": "update", "updates": {"city": "Sydney"}}
+```
+
+## Findings...
+
+```json
+[{"id": "real-1", "name": "RealCo", "verdict": "update", "updates": {}}]
+```
+"""
+    result = p._extract_json_array(text)
+    assert isinstance(result, list)
+    assert result[0]["id"] == "real-1"
+    assert len(result) == 1
+
+
+def test_extract_json_array_repairs_markdown_escapes_and_empty_fields() -> None:
+    """Gemini DR sometimes prints JSON outside fences with markdown escapes."""
+    text = r"""
+Some narrative.
+
+\[
+  {
+    "id": "company-1",
+    "name": "GeminiCo",
+    "verdict": "update",
+    "updates": {
+      "stage": "series\_a",
+      "founders":,
+      "evidence\_urls":
+    },
+    "evidence\_urls": \["https://example.com"\],
+    "confidence": 0.9
+  }
+\]
+"""
+    result = p._extract_json_array(text)
+    assert isinstance(result, list)
+    assert result[0]["id"] == "company-1"
+    assert result[0]["updates"]["stage"] == "series_a"
+    # Empty `founders":,` fields became null after repair.
+    assert result[0]["updates"]["founders"] is None
+
+
+def test_extract_json_array_collects_separate_id_bearing_objects() -> None:
+    """Some Gemini outputs emit one JSON object per company, not one array."""
+    text = """
+## Cohort report
+
+```json
+{"id": "co-1", "name": "First", "verdict": "update", "updates": {}}
+```
+
+```json
+{"id": "co-2", "name": "Second", "verdict": "confirm", "updates": {}}
+```
+"""
+    result = p._extract_json_array(text)
+    assert isinstance(result, list)
+    assert {entry["id"] for entry in result} == {"co-1", "co-2"}
+
+
+def test_validate_entry_normalises_string_confidence_labels() -> None:
+    entry = {
+        "id": "co-1",
+        "name": "LabelCo",
+        "verdict": "update",
+        "updates": {"profile_confidence": "high"},
+        "evidence_urls": ["https://example.com"],
+    }
+    parsed, errors = p._validate_entry(entry)
+    assert parsed is not None
+    assert parsed.updates["profile_confidence"] == 0.9
+    # The substitution should be surfaced as a (non-fatal) warning.
+    assert any("normalised" in e for e in errors)
+
+
+def test_validate_entry_drops_unknown_confidence_label() -> None:
+    entry = {
+        "id": "co-1",
+        "name": "WeirdCo",
+        "verdict": "update",
+        "updates": {"profile_confidence": "VERY VERY HIGH"},
+        "evidence_urls": ["https://example.com"],
+    }
+    parsed, errors = p._validate_entry(entry)
+    assert parsed is not None
+    assert "profile_confidence" not in parsed.updates
+    assert any("not recognised" in e for e in errors)
+
+
+def test_validate_entry_normalises_flat_schema_to_updates() -> None:
+    """A flat-schema entry (every field at the top level) should be promoted."""
+    entry = {
+        "id": "co-1",
+        "name": "FlatCo",
+        "city": "Sydney",
+        "stage": "seed",
+        "founded_year": 2022,
+    }
+    parsed, errors = p._validate_entry(entry)
+    assert parsed is not None
+    assert parsed.verdict == "update"
+    assert parsed.updates["city"] == "Sydney"
+    assert parsed.updates["stage"] == "seed"
+    assert parsed.updates["founded_year"] == 2022
+
+
+def test_run_parse_writes_apply_and_flags_artifacts(tmp_path: Path) -> None:
+    responses = tmp_path / "responses"
+    responses.mkdir()
+    (responses / "verify_x.md").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "co-1",
+                    "name": "GoodCo",
+                    "verdict": "update",
+                    "updates": {"city": "Sydney"},
+                    "evidence_urls": ["https://example.com"],
+                    "confidence": 0.9,
+                },
+                {
+                    "id": "co-2",
+                    "name": "BadCo",
+                    "verdict": "flag_for_rejection",
+                    "evidence_urls": [],
+                    "notes": "Defunct.",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    summary = p.run_parse(input_dir=tmp_path, write=True)
+    assert summary.errors == []
+    assert summary.entries_seen == 2
+    assert summary.by_verdict.get("update") == 1
+    assert summary.by_verdict.get("flag_for_rejection") == 1
+
+    apply_payload = json.loads(Path(summary.apply_path).read_text(encoding="utf-8"))
+    assert apply_payload["companies"][0]["id"] == "co-1"
+    assert apply_payload["companies"][0]["updates"]["city"] == "Sydney"
+
+    flags_payload = json.loads(Path(summary.flags_path).read_text(encoding="utf-8"))
+    assert flags_payload["companies"][0]["id"] == "co-2"
+
+
+def test_run_parse_merges_multi_sector_entries(tmp_path: Path) -> None:
+    """Same company id appearing in two responses gets merged."""
+    responses = tmp_path / "responses"
+    responses.mkdir()
+    (responses / "verify_a.md").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "shared-co",
+                    "name": "SharedCo",
+                    "verdict": "update",
+                    "updates": {"city": "Sydney"},
+                    "evidence_urls": ["https://a.example.com"],
+                    "confidence": 0.85,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (responses / "verify_b.md").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "shared-co",
+                    "name": "SharedCo",
+                    "verdict": "confirm",
+                    "updates": {},
+                    "evidence_urls": ["https://b.example.com"],
+                    "confidence": 0.9,
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    summary = p.run_parse(input_dir=tmp_path, write=True)
+    apply_payload = json.loads(Path(summary.apply_path).read_text(encoding="utf-8"))
+    assert len(apply_payload["companies"]) == 1
+    merged = apply_payload["companies"][0]
+    assert merged["updates"]["city"] == "Sydney"  # update verdict wins over confirm
+    # Sources from both responses are unioned.
+    assert sorted(merged["evidence_urls"]) == [
+        "https://a.example.com",
+        "https://b.example.com",
+    ]
+
+
+def test_run_parse_flags_conflicting_updates(tmp_path: Path) -> None:
+    """If two responses give different values for the same field, route to flags."""
+    responses = tmp_path / "responses"
+    responses.mkdir()
+    for idx, city in enumerate(("Sydney", "Melbourne")):
+        (responses / f"verify_{idx}.md").write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "shared",
+                        "name": "Shared",
+                        "verdict": "update",
+                        "updates": {"city": city},
+                        "evidence_urls": [f"https://{idx}.example.com"],
+                        "confidence": 0.9,
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    summary = p.run_parse(input_dir=tmp_path, write=True)
+    assert summary.conflicts and "city" in summary.conflicts[0]
+    flags_payload = json.loads(Path(summary.flags_path).read_text(encoding="utf-8"))
+    assert flags_payload["companies"][0]["verdict"] == "flag_for_review"


### PR DESCRIPTION
## Summary

What this PR does in one or two sentences.

## Why

What problem does it solve? What does it enable?

## Changes

- ...
- ...
- ...

## Test plan

- [ ] `pytest -q` passes
- [ ] `ruff check .` passes
- [ ] `black --check .` passes
- [ ] Manual smoke check (describe)
- [ ] `PROJECT_PROGRESS.md` updated *if* this is a milestone (closes Now/Next issue, ships public feature, breaks something). Otherwise leave alone.

## Multi-agent coordination

- [ ] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [ ] I am the assignee on the linked issue
- [ ] Branch is named `<tool>/<issue-number>-<slug>`
- [ ] Rebased on latest `main` (no merge conflicts with other in-flight PRs)

## Screenshots

(If this changes the dashboard.)

## Related issues

Closes #

Closes #101

## What this PR does

Lands the deep-research verification toolkit that drove the recent 42-company
data refresh and 16-company rejection batch. Until now these scripts lived as
a stash in main, which made re-runs and onboarding harder.

## Files added

- `prompts/verify_sector.md` - master prompt template for one cohort, with
  enum-constrained fields and a worked example.
- `scripts/dump_verified_companies.py` - read-only Supabase dump helper.
- `scripts/generate_verification_prompts.py` - sector and group-bucket prompt
  generator with deterministic naming.
- `scripts/parse_verification_responses.py` - parser tolerant of Gemini and
  ChatGPT output styles (fenced JSON, escaped JSON outside fences, per-company
  objects, and flat-schema entries).
- `.gitignore` adds `data/verification/` so generated artifacts stay local.

## Parser hardening

Gemini sometimes emits `profile_confidence` as the strings `"high"`, `"medium"`
or `"low"`, which previously crashed the apply with
`psycopg.errors.InvalidTextRepresentation`. The parser now normalises those
labels to mid-band floats (0.9 / 0.7 / 0.4) inside `_validate_entry` and
surfaces a one-line warning. Removes the manual JSON-edit step that has been
needed every apply cycle.

## Tests

- 6 generator tests (bucketing, dedupe within group, render shape, write,
  dry-run, oversized-bucket splitting)
- 9 parser tests (fenced-block extraction, markdown-escape repair, per-object
  collection, flat-schema normalisation, confidence-label normalisation,
  unknown-label drop, apply/flags artifact write, multi-source merge,
  conflict flagging)
- All fixture-driven, no live DB.
- `pytest -q`: 185 pass, 2 skip (unrelated live-DB).
- `ruff check .` and `black --check .` clean.

## Out of scope

- `--since` flag on the dump helper (queued as a small follow-up issue).
- Discovery flow (issue #99).
