### PR TITLE
[#103] [feature] add --since flag to dump_verified_companies for incremental re-runs

### DIFF
--- a/scripts/dump_verified_companies.py
+++ b/scripts/dump_verified_companies.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python3
-"""Dump every verified company to a local JSON file for offline inspection.
+"""Dump verified companies to a local JSON file for offline inspection.
 
 Used by the verification-prompt curation flow: an agent reads the dumped
 JSON, decides groupings, and emits paste-ready prompts. Dump is read-only.
 
+By default dumps every verified company. With `--since YYYY-MM-DD`, dumps
+only the companies whose `profile_verified_at` is strictly older than the
+given date OR null - useful for incremental re-verification cycles where
+freshly-verified rows do not need to be re-asked.
+
 Usage:
     op run --env-file=.env.local -- python scripts/dump_verified_companies.py
+    op run --env-file=.env.local -- python scripts/dump_verified_companies.py --since 2026-01-30
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import sys
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -38,18 +45,88 @@ def _json_default(value: Any) -> Any:
     return str(value)
 
 
-def main() -> int:
-    """Read all verified companies from Supabase, write to DEFAULT_OUTPUT_PATH."""
+def _row_verified_at(row: dict[str, Any]) -> datetime | None:
+    value = row.get("profile_verified_at")
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    return None
+
+
+def filter_since(rows: list[dict[str, Any]], cutoff: date) -> list[dict[str, Any]]:
+    """Keep rows whose `profile_verified_at` is None or strictly older than `cutoff`.
+
+    Cutoff is interpreted as midnight UTC on the given date.
+    """
+    cutoff_dt = datetime.combine(cutoff, datetime.min.time(), tzinfo=UTC)
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        verified_at = _row_verified_at(row)
+        if verified_at is None or verified_at < cutoff_dt:
+            out.append(row)
+    return out
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since",
+        type=date.fromisoformat,
+        default=None,
+        help=(
+            "Only dump companies with profile_verified_at older than YYYY-MM-DD "
+            "(or null). Default: dump all verified."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Output JSON path.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Read verified companies from Supabase, optionally filter, write JSON."""
     configure_logging()
+    args = parse_args(argv)
     with supabase_db.connection() as conn:
         rows = supabase_db.list_companies(conn, statuses=("verified",))
-    DEFAULT_OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    DEFAULT_OUTPUT_PATH.write_text(
+    total = len(rows)
+    if args.since is not None:
+        rows = filter_since(rows, args.since)
+        LOGGER.info(
+            "filter --since %s: kept %d of %d (older than cutoff or never verified)",
+            args.since.isoformat(),
+            len(rows),
+            total,
+        )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
         json.dumps(rows, indent=2, default=_json_default, sort_keys=False),
         encoding="utf-8",
     )
-    LOGGER.info("wrote %d verified companies to %s", len(rows), DEFAULT_OUTPUT_PATH)
-    print(json.dumps({"count": len(rows), "path": str(DEFAULT_OUTPUT_PATH)}, indent=2))
+    LOGGER.info("wrote %d verified companies to %s", len(rows), args.output)
+    print(
+        json.dumps(
+            {
+                "count": len(rows),
+                "total_verified": total,
+                "since": args.since.isoformat() if args.since else None,
+                "path": str(args.output),
+            },
+            indent=2,
+        )
+    )
     return 0
 
 

--- a/tests/test_dump_verified_companies.py
+++ b/tests/test_dump_verified_companies.py
@@ -1,0 +1,53 @@
+"""Tests for dump_verified_companies --since filter."""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import dump_verified_companies as dump  # noqa: E402
+
+
+def _row(name: str, verified_at: datetime | str | None) -> dict[str, object]:
+    return {"id": f"id-{name}", "name": name, "profile_verified_at": verified_at}
+
+
+def test_filter_since_keeps_old_and_unverified() -> None:
+    cutoff = date(2026, 4, 1)
+    rows = [
+        _row("Fresh", datetime(2026, 4, 15, tzinfo=UTC)),
+        _row("Stale", datetime(2026, 1, 5, tzinfo=UTC)),
+        _row("NeverVerified", None),
+        _row("ExactlyAtCutoff", datetime(2026, 4, 1, tzinfo=UTC)),
+    ]
+
+    kept = dump.filter_since(rows, cutoff)
+
+    names = {r["name"] for r in kept}
+    # Older-than-cutoff and null verified_at survive; on-or-after cutoff drops.
+    assert names == {"Stale", "NeverVerified"}
+
+
+def test_filter_since_handles_iso_string_and_naive_datetime() -> None:
+    cutoff = date(2026, 4, 1)
+    rows = [
+        _row("StringIso", "2026-01-05T00:00:00+00:00"),
+        _row("NaiveDatetime", datetime(2026, 1, 5)),  # no tzinfo, treated as UTC
+        _row("FreshString", "2026-04-15T00:00:00+00:00"),
+    ]
+
+    kept = dump.filter_since(rows, cutoff)
+
+    names = {r["name"] for r in kept}
+    assert names == {"StringIso", "NaiveDatetime"}
+
+
+def test_filter_since_returns_empty_when_all_are_fresh() -> None:
+    cutoff = date(2026, 1, 1)
+    rows = [_row("Fresh", datetime(2026, 6, 1, tzinfo=UTC))]
+
+    assert dump.filter_since(rows, cutoff) == []


### PR DESCRIPTION
## Summary

What this PR does in one or two sentences.

## Why

What problem does it solve? What does it enable?

## Changes

- ...
- ...
- ...

## Test plan

- [ ] `pytest -q` passes
- [ ] `ruff check .` passes
- [ ] `black --check .` passes
- [ ] Manual smoke check (describe)
- [ ] `PROJECT_PROGRESS.md` updated *if* this is a milestone (closes Now/Next issue, ships public feature, breaks something). Otherwise leave alone.

## Multi-agent coordination

- [ ] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [ ] I am the assignee on the linked issue
- [ ] Branch is named `<tool>/<issue-number>-<slug>`
- [ ] Rebased on latest `main` (no merge conflicts with other in-flight PRs)

## Screenshots

(If this changes the dashboard.)

## Related issues

Closes #

Closes #103

## What this PR does

Adds `--since YYYY-MM-DD` to `scripts/dump_verified_companies.py` so a
re-verification cycle only re-asks about stale rows. Companies whose
`profile_verified_at` is null or strictly older than the cutoff are kept;
freshly-verified rows are filtered out.

## Why

Quarterly cadence: when we re-run the deep-research pass, we do not want to
spend Gemini DR / ChatGPT DR quota and human paste time re-verifying the
rows we just verified. With `--since` set to ~90 days back, the dump
naturally focuses on what needs attention.

## Behaviour

- Default (no flag): same as before, dumps every verified company.
- `--since 2026-01-30`: keeps rows with `profile_verified_at` null or
  before midnight UTC on that date.
- `--output` lets the caller redirect the JSON path.

## Tests

Three fixture-driven tests covering:

- The basic filter (older + null kept, on-or-after cutoff dropped)
- ISO-string and timezone-naive datetime inputs
- All-fresh case returns empty

Full `pytest -q`: 188 pass, 2 skip (unrelated live-DB).
`ruff check` and `black --check` clean.
