### PR TITLE
[#100] [feature] surface freshness on the map and company directory

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -24,7 +24,7 @@ contact details out of this file. Routine fixes belong in PR bodies.
   "Recently funded") to the companies directory. A unified sort dropdown
   replaces the previous header-only column sort.
 - Uses existing fields only (`profile_verified_at`, `total_raised_as_of`); no
-  schema or API change. Thresholds: 30 days for verified, 90 days for funded.
+  schema or API change. Thresholds: 14 days for verified, 90 days for funded.
 
 ### 2026-04-30: Verification Tooling Committed
 

--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -15,6 +15,17 @@ contact details out of this file. Routine fixes belong in PR bodies.
 
 ## Recent Milestones
 
+### 2026-04-30: Surface Freshness On The Map And Directory
+
+- Recently verified and newly funded companies now read at a glance on every
+  public surface: badges in the directory list, the company profile, and the
+  map detail panel; an outline ring on the corresponding map markers.
+- Added a Freshness filter chip and matching sort options ("Recently verified",
+  "Recently funded") to the companies directory. A unified sort dropdown
+  replaces the previous header-only column sort.
+- Uses existing fields only (`profile_verified_at`, `total_raised_as_of`); no
+  schema or API change. Thresholds: 30 days for verified, 90 days for funded.
+
 ### 2026-04-30: Verification Tooling Committed
 
 - Added the deep-research verification toolkit to the repo so future re-runs

--- a/web/src/components/companies/CompaniesDirectory.tsx
+++ b/web/src/components/companies/CompaniesDirectory.tsx
@@ -6,21 +6,23 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink } from "lucide-react";
 
 import { CompaniesFilterBar } from "./CompaniesFilterBar";
+import { FreshnessBadges } from "./FreshnessBadges";
 import {
   applyFilters,
   deriveMeta,
   filtersToParams,
   paramsToFilters,
 } from "@/lib/filters";
+import { fundedAtMs, verifiedAtMs } from "@/lib/freshness";
 import { primarySectorHex, sectorLabel } from "@/lib/taxonomy";
 import { formatStage } from "@/lib/format";
 import { slugFor } from "@/lib/slug";
 import { cn } from "@/lib/cn";
 import type { Company } from "@/lib/types";
 
-type SortKey = "name" | "founded";
+type SortKey = "name" | "founded" | "verified" | "funded";
 type SortDir = "asc" | "desc";
-const SORT_KEYS: SortKey[] = ["name", "founded"];
+const SORT_KEYS: SortKey[] = ["name", "founded", "verified", "funded"];
 
 export function CompaniesDirectory() {
   const router = useRouter();
@@ -53,7 +55,13 @@ export function CompaniesDirectory() {
   const sortKey = SORT_KEYS.includes(requestedSort as SortKey)
     ? (requestedSort as SortKey)
     : "name";
-  const sortDir = (searchParams.get("dir") as SortDir) || "asc";
+  const requestedDir = searchParams.get("dir");
+  const sortDir: SortDir =
+    requestedDir === "asc" || requestedDir === "desc"
+      ? requestedDir
+      : sortKey === "verified" || sortKey === "funded"
+        ? "desc"
+        : "asc";
 
   const filtered = useMemo(
     () => applyFilters(companies ?? [], filterState),
@@ -67,8 +75,10 @@ export function CompaniesDirectory() {
       const next = filtersToParams(overrides.state ?? filterState);
       const finalSort = overrides.sort ?? sortKey;
       const finalDir = overrides.dir ?? sortDir;
+      const defaultDir: SortDir =
+        finalSort === "verified" || finalSort === "funded" ? "desc" : "asc";
       if (finalSort !== "name") next.set("sort", finalSort);
-      if (finalDir !== "asc") next.set("dir", finalDir);
+      if (finalDir !== defaultDir) next.set("dir", finalDir);
       const qs = next.toString();
       router.replace(qs ? `/companies?${qs}` : "/companies", { scroll: false });
     },
@@ -77,7 +87,9 @@ export function CompaniesDirectory() {
 
   const onSort = useCallback(
     (key: SortKey) => {
-      const nextDir: SortDir = sortKey === key ? (sortDir === "asc" ? "desc" : "asc") : "asc";
+      const defaultDir: SortDir = key === "verified" || key === "funded" ? "desc" : "asc";
+      const nextDir: SortDir =
+        sortKey === key ? (sortDir === "asc" ? "desc" : "asc") : defaultDir;
       updateUrl({ sort: key, dir: nextDir });
     },
     [sortKey, sortDir, updateUrl],
@@ -113,6 +125,9 @@ export function CompaniesDirectory() {
           state={filterState}
           meta={meta}
           onChange={(next) => updateUrl({ state: next })}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSortChange={(key, dir) => updateUrl({ sort: key, dir })}
         />
       </div>
 
@@ -170,6 +185,7 @@ export function CompaniesDirectory() {
                           >
                             {c.name}
                           </Link>
+                          <FreshnessBadges company={c} />
                           {c.website && (
                             <a
                               href={c.website}
@@ -225,7 +241,10 @@ export function CompaniesDirectory() {
                   <div className="h-1 w-full" style={{ background: accent }} aria-hidden />
                   <Link href={`/companies/${slug}`} className="block px-4 py-4">
                     <div className="flex items-start justify-between gap-3">
-                      <h3 className="text-[15px] font-semibold text-text">{c.name}</h3>
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                        <h3 className="text-[15px] font-semibold text-text">{c.name}</h3>
+                        <FreshnessBadges company={c} />
+                      </div>
                       <span className="text-[11px] text-text-subtle whitespace-nowrap">
                         {[c.city, c.country].filter(Boolean).join(", ")}
                       </span>
@@ -305,6 +324,18 @@ function sortCompanies(items: Company[], key: SortKey, dir: SortDir): Company[] 
   switch (key) {
     case "founded":
       sorted.sort((a, b) => mult * cmpNullable(a.founded_year, b.founded_year));
+      break;
+    case "verified":
+      sorted.sort((a, b) => {
+        const cmp = cmpNullable(verifiedAtMs(a), verifiedAtMs(b));
+        return cmp !== 0 ? mult * cmp : a.name.localeCompare(b.name);
+      });
+      break;
+    case "funded":
+      sorted.sort((a, b) => {
+        const cmp = cmpNullable(fundedAtMs(a), fundedAtMs(b));
+        return cmp !== 0 ? mult * cmp : a.name.localeCompare(b.name);
+      });
       break;
     case "name":
     default:

--- a/web/src/components/companies/CompaniesDirectory.tsx
+++ b/web/src/components/companies/CompaniesDirectory.tsx
@@ -313,28 +313,35 @@ function SortableTh({
 
 function sortCompanies(items: Company[], key: SortKey, dir: SortDir): Company[] {
   const mult = dir === "asc" ? 1 : -1;
-  const cmpNullable = (a: number | null, b: number | null): number => {
-    if (a === null && b === null) return 0;
-    if (a === null) return 1; // nulls last
+
+  // Compare two numbers, always keeping nulls at the end regardless of
+  // direction. Returns null when both sides are null so the caller can fall
+  // back to a stable secondary key.
+  const cmpNullsLast = (a: number | null, b: number | null): number | null => {
+    if (a === null && b === null) return null;
+    if (a === null) return 1;
     if (b === null) return -1;
-    return a - b;
+    return mult * (a - b);
   };
 
   const sorted = [...items];
   switch (key) {
     case "founded":
-      sorted.sort((a, b) => mult * cmpNullable(a.founded_year, b.founded_year));
+      sorted.sort((a, b) => {
+        const cmp = cmpNullsLast(a.founded_year, b.founded_year);
+        return cmp ?? a.name.localeCompare(b.name);
+      });
       break;
     case "verified":
       sorted.sort((a, b) => {
-        const cmp = cmpNullable(verifiedAtMs(a), verifiedAtMs(b));
-        return cmp !== 0 ? mult * cmp : a.name.localeCompare(b.name);
+        const cmp = cmpNullsLast(verifiedAtMs(a), verifiedAtMs(b));
+        return cmp ?? a.name.localeCompare(b.name);
       });
       break;
     case "funded":
       sorted.sort((a, b) => {
-        const cmp = cmpNullable(fundedAtMs(a), fundedAtMs(b));
-        return cmp !== 0 ? mult * cmp : a.name.localeCompare(b.name);
+        const cmp = cmpNullsLast(fundedAtMs(a), fundedAtMs(b));
+        return cmp ?? a.name.localeCompare(b.name);
       });
       break;
     case "name":

--- a/web/src/components/companies/CompaniesDirectory.tsx
+++ b/web/src/components/companies/CompaniesDirectory.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 
 import { CompaniesFilterBar } from "./CompaniesFilterBar";
 import { FreshnessBadges } from "./FreshnessBadges";
@@ -17,7 +17,6 @@ import { fundedAtMs, verifiedAtMs } from "@/lib/freshness";
 import { primarySectorHex, sectorLabel } from "@/lib/taxonomy";
 import { formatStage } from "@/lib/format";
 import { slugFor } from "@/lib/slug";
-import { cn } from "@/lib/cn";
 import type { Company } from "@/lib/types";
 
 type SortKey = "name" | "founded" | "verified" | "funded";
@@ -85,16 +84,6 @@ export function CompaniesDirectory() {
     [filterState, sortKey, sortDir, router],
   );
 
-  const onSort = useCallback(
-    (key: SortKey) => {
-      const defaultDir: SortDir = key === "verified" || key === "funded" ? "desc" : "asc";
-      const nextDir: SortDir =
-        sortKey === key ? (sortDir === "asc" ? "desc" : "asc") : defaultDir;
-      updateUrl({ sort: key, dir: nextDir });
-    },
-    [sortKey, sortDir, updateUrl],
-  );
-
   return (
     <section className="mx-auto w-full max-w-[1200px] px-5 py-10">
       <div className="flex flex-wrap items-end justify-between gap-3">
@@ -156,9 +145,9 @@ export function CompaniesDirectory() {
             <table className="w-full text-[13px]">
               <thead className="border-b border-border text-text-muted">
                 <tr className="text-left">
-                  <SortableTh label="Name" active={sortKey} dir={sortDir} field="name" onSort={onSort} />
+                  <th className="px-4 py-2 font-medium">Name</th>
                   <th className="px-4 py-2 font-medium">Stage</th>
-                  <SortableTh label="Founded" active={sortKey} dir={sortDir} field="founded" onSort={onSort} />
+                  <th className="px-4 py-2 font-medium">Founded</th>
                   <th className="px-4 py-2 font-medium">Sectors</th>
                   <th className="px-4 py-2 font-medium">Location</th>
                 </tr>
@@ -276,38 +265,6 @@ export function CompaniesDirectory() {
         </>
       )}
     </section>
-  );
-}
-
-function SortableTh({
-  label,
-  active,
-  dir,
-  field,
-  onSort,
-}: {
-  label: string;
-  active: SortKey;
-  dir: SortDir;
-  field: SortKey;
-  onSort: (k: SortKey) => void;
-}) {
-  const isActive = active === field;
-  const Icon = !isActive ? ArrowUpDown : dir === "asc" ? ArrowUp : ArrowDown;
-  return (
-    <th className="px-4 py-2 font-medium">
-      <button
-        type="button"
-        onClick={() => onSort(field)}
-        className={cn(
-          "inline-flex items-center gap-1 transition-colors",
-          isActive ? "text-text" : "text-text-muted hover:text-text",
-        )}
-      >
-        {label}
-        <Icon className="h-3 w-3" />
-      </button>
-    </th>
   );
 }
 

--- a/web/src/components/companies/CompaniesFilterBar.tsx
+++ b/web/src/components/companies/CompaniesFilterBar.tsx
@@ -7,20 +7,45 @@ import {
   type FilterState,
   isFilterActive,
 } from "@/lib/filters";
+import { FRESHNESS_OPTIONS, type FreshnessFlag } from "@/lib/freshness";
 import {
   MultiSelect,
   ResetButton,
   SearchInput,
+  SingleSelect,
   YearRange,
 } from "@/components/filters/primitives";
+
+type DirectorySortKey = "name" | "founded" | "verified" | "funded";
+type SortDir = "asc" | "desc";
+
+const SORT_OPTIONS: { value: string; label: string }[] = [
+  { value: "name:asc", label: "Name A to Z" },
+  { value: "name:desc", label: "Name Z to A" },
+  { value: "founded:desc", label: "Newest founded" },
+  { value: "founded:asc", label: "Oldest founded" },
+  { value: "verified:desc", label: "Recently verified" },
+  { value: "funded:desc", label: "Recently funded" },
+];
 
 interface Props {
   state: FilterState;
   meta: FilterMeta;
   onChange: (next: FilterState) => void;
+  sortKey: DirectorySortKey;
+  sortDir: SortDir;
+  onSortChange: (key: DirectorySortKey, dir: SortDir) => void;
 }
 
-export function CompaniesFilterBar({ state, meta, onChange }: Props) {
+export function CompaniesFilterBar({
+  state,
+  meta,
+  onChange,
+  sortKey,
+  sortDir,
+  onSortChange,
+}: Props) {
+  const sortValue = `${sortKey}:${sortDir}`;
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-xl border border-border bg-surface/60 px-3 py-2.5">
       <SearchInput
@@ -49,6 +74,15 @@ export function CompaniesFilterBar({ state, meta, onChange }: Props) {
         onChange={(countries) => onChange({ ...state, countries })}
       />
 
+      <MultiSelect
+        label="Freshness"
+        options={FRESHNESS_OPTIONS}
+        selected={state.freshness}
+        onChange={(values) =>
+          onChange({ ...state, freshness: values as FreshnessFlag[] })
+        }
+      />
+
       <YearRange
         meta={meta}
         min={state.foundedMin}
@@ -56,6 +90,16 @@ export function CompaniesFilterBar({ state, meta, onChange }: Props) {
         onChange={(foundedMin, foundedMax) =>
           onChange({ ...state, foundedMin, foundedMax })
         }
+      />
+
+      <SingleSelect
+        label="Sort"
+        value={sortValue}
+        options={SORT_OPTIONS}
+        onChange={(value) => {
+          const [key, dir] = value.split(":") as [DirectorySortKey, SortDir];
+          onSortChange(key, dir);
+        }}
       />
 
       {isFilterActive(state) && (

--- a/web/src/components/companies/CompanyProfile.tsx
+++ b/web/src/components/companies/CompanyProfile.tsx
@@ -10,6 +10,7 @@ import {
   formatStage,
   formatUsd,
 } from "@/lib/format";
+import { FreshnessBadges } from "./FreshnessBadges";
 
 interface Props {
   company: Company;
@@ -38,9 +39,12 @@ export function CompanyProfile({ company }: Props) {
         <header className="border-b border-border px-6 py-6">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div className="min-w-0">
-              <h1 className="text-3xl font-semibold tracking-tight text-text sm:text-4xl">
-                {company.name}
-              </h1>
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="text-3xl font-semibold tracking-tight text-text sm:text-4xl">
+                  {company.name}
+                </h1>
+                <FreshnessBadges company={company} variant="chip" />
+              </div>
               {location && (
                 <p className="mt-1.5 text-[14px] text-text-muted">{location}</p>
               )}

--- a/web/src/components/companies/FreshnessBadges.tsx
+++ b/web/src/components/companies/FreshnessBadges.tsx
@@ -1,0 +1,93 @@
+import { Sparkles, TrendingUp } from "lucide-react";
+
+import type { Company } from "@/lib/types";
+import {
+  RECENTLY_FUNDED_DAYS,
+  RECENTLY_VERIFIED_DAYS,
+  isRecentlyFunded,
+  isRecentlyVerified,
+} from "@/lib/freshness";
+import { cn } from "@/lib/cn";
+
+type Variant = "icon" | "chip";
+
+interface Props {
+  company: Company;
+  variant?: Variant;
+  className?: string;
+}
+
+export function FreshnessBadges({ company, variant = "icon", className }: Props) {
+  const verified = isRecentlyVerified(company);
+  const funded = isRecentlyFunded(company);
+  if (!verified && !funded) return null;
+
+  return (
+    <span className={cn("inline-flex items-center gap-1", className)}>
+      {verified && (
+        <Badge
+          variant={variant}
+          tone="verified"
+          icon={<Sparkles className="h-3 w-3" />}
+          label="Recently verified"
+          title={`Verified in the last ${RECENTLY_VERIFIED_DAYS} days`}
+        />
+      )}
+      {funded && (
+        <Badge
+          variant={variant}
+          tone="funded"
+          icon={<TrendingUp className="h-3 w-3" />}
+          label="Newly funded"
+          title={`Total raised confirmed in the last ${RECENTLY_FUNDED_DAYS} days`}
+        />
+      )}
+    </span>
+  );
+}
+
+function Badge({
+  variant,
+  tone,
+  icon,
+  label,
+  title,
+}: {
+  variant: Variant;
+  tone: "verified" | "funded";
+  icon: React.ReactNode;
+  label: string;
+  title: string;
+}) {
+  const palette =
+    tone === "verified"
+      ? "border-accent/40 bg-accent-soft text-accent"
+      : "border-success/40 bg-success/10 text-success";
+
+  if (variant === "icon") {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center justify-center rounded-full border p-0.5",
+          palette,
+        )}
+        title={title}
+        aria-label={label}
+      >
+        {icon}
+      </span>
+    );
+  }
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+        palette,
+      )}
+      title={title}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}

--- a/web/src/components/filters/primitives.tsx
+++ b/web/src/components/filters/primitives.tsx
@@ -127,6 +127,88 @@ export function MultiSelect({
   );
 }
 
+export function SingleSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: Option[];
+  onChange: (next: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const esc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    document.addEventListener("keydown", esc);
+    return () => {
+      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("keydown", esc);
+    };
+  }, [open]);
+
+  const current = options.find((o) => o.value === value);
+  const summary = current ? `${label}: ${current.label}` : label;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((s) => !s)}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[13px] font-medium transition-colors",
+          "border-border bg-surface-2 text-text-muted hover:border-border-strong hover:text-text",
+        )}
+      >
+        {summary}
+        <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", open && "rotate-180")} />
+      </button>
+
+      {open && options.length > 0 && (
+        <div className="aisw-scroll absolute right-0 top-full z-20 mt-1 max-h-[280px] w-[220px] overflow-y-auto rounded-md border border-border bg-surface shadow-2xl">
+          <ul role="listbox" className="py-1">
+            {options.map((opt) => {
+              const checked = opt.value === value;
+              return (
+                <li key={opt.value}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={checked}
+                    onClick={() => {
+                      onChange(opt.value);
+                      setOpen(false);
+                    }}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-[13px] transition-colors",
+                      checked
+                        ? "text-accent hover:bg-accent-soft"
+                        : "text-text hover:bg-surface-2",
+                    )}
+                  >
+                    <span className="truncate">{opt.label}</span>
+                    {checked && <Check className="h-3.5 w-3.5 shrink-0" />}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function YearRange({
   meta,
   min,

--- a/web/src/components/map/CompanyDetail.tsx
+++ b/web/src/components/map/CompanyDetail.tsx
@@ -12,6 +12,7 @@ import {
   formatStage,
   formatUsd,
 } from "@/lib/format";
+import { FreshnessBadges } from "@/components/companies/FreshnessBadges";
 
 interface Props {
   company: Company | null;
@@ -66,8 +67,9 @@ export function CompanyDetail({ company, onClose }: Props) {
               company.name
             )}
           </h2>
+          <FreshnessBadges company={company} variant="chip" className="mt-1.5 flex flex-wrap gap-1" />
           {location && (
-            <p className="mt-0.5 text-[12px] text-text-muted">{location}</p>
+            <p className="mt-1 text-[12px] text-text-muted">{location}</p>
           )}
         </div>
         <button

--- a/web/src/components/map/FilterBar.tsx
+++ b/web/src/components/map/FilterBar.tsx
@@ -7,6 +7,7 @@ import {
   type FilterState,
   isFilterActive,
 } from "@/lib/filters";
+import { FRESHNESS_OPTIONS, type FreshnessFlag } from "@/lib/freshness";
 import {
   MultiSelect,
   ResetButton,
@@ -49,6 +50,15 @@ export function FilterBar({ state, meta, onChange, visibleCount, totalCount }: P
         options={meta.countries.map((c) => ({ value: c, label: c }))}
         selected={state.countries}
         onChange={(countries) => onChange({ ...state, countries })}
+      />
+
+      <MultiSelect
+        label="Freshness"
+        options={FRESHNESS_OPTIONS}
+        selected={state.freshness}
+        onChange={(values) =>
+          onChange({ ...state, freshness: values as FreshnessFlag[] })
+        }
       />
 
       <YearRange

--- a/web/src/components/map/Map.tsx
+++ b/web/src/components/map/Map.tsx
@@ -141,7 +141,7 @@ export function Map({ companies, selectedId, onSelect }: MapProps) {
         }
         .aisw-marker--fresh {
           box-shadow: 0 0 0 1px rgba(255,255,255,0.2),
-                      0 0 0 4px rgba(244,183,64,0.55),
+                      0 0 0 4px rgba(61,220,132,0.55),
                       0 4px 10px rgba(0,0,0,0.4);
         }
         .aisw-marker:hover {
@@ -150,7 +150,7 @@ export function Map({ companies, selectedId, onSelect }: MapProps) {
         }
         .aisw-marker--fresh:hover {
           box-shadow: 0 0 0 2px rgba(244,183,64,0.6),
-                      0 0 0 5px rgba(244,183,64,0.35),
+                      0 0 0 5px rgba(61,220,132,0.5),
                       0 6px 14px rgba(0,0,0,0.5);
         }
         .aisw-marker--selected {

--- a/web/src/components/map/Map.tsx
+++ b/web/src/components/map/Map.tsx
@@ -7,6 +7,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 
 import type { Company } from "@/lib/types";
 import { primarySectorHex } from "@/lib/taxonomy";
+import { isRecentlyFunded, isRecentlyVerified } from "@/lib/freshness";
 
 interface MapProps {
   companies: Company[];
@@ -26,6 +27,7 @@ interface PointProps {
   companyId: string;
   name: string;
   hex: string;
+  fresh: boolean;
 }
 
 type ClusterFeature =
@@ -45,6 +47,7 @@ export function Map({ companies, selectedId, onSelect }: MapProps) {
 
   // Build the supercluster index from the filtered companies.
   const features = useMemo<Supercluster.PointFeature<PointProps>[]>(() => {
+    const now = new Date();
     return companies
       .filter((c) => c.lat !== null && c.lon !== null)
       .map((c) => ({
@@ -53,6 +56,7 @@ export function Map({ companies, selectedId, onSelect }: MapProps) {
           companyId: c.id,
           name: c.name,
           hex: primarySectorHex(c.sector_tags),
+          fresh: isRecentlyVerified(c, now) || isRecentlyFunded(c, now),
         },
         geometry: { type: "Point", coordinates: [c.lon as number, c.lat as number] },
       }));
@@ -135,9 +139,19 @@ export function Map({ companies, selectedId, onSelect }: MapProps) {
           cursor: pointer;
           transition: transform 120ms ease, box-shadow 120ms ease;
         }
+        .aisw-marker--fresh {
+          box-shadow: 0 0 0 1px rgba(255,255,255,0.2),
+                      0 0 0 4px rgba(244,183,64,0.55),
+                      0 4px 10px rgba(0,0,0,0.4);
+        }
         .aisw-marker:hover {
           transform: scale(1.35);
           box-shadow: 0 0 0 2px rgba(244,183,64,0.6), 0 6px 14px rgba(0,0,0,0.5);
+        }
+        .aisw-marker--fresh:hover {
+          box-shadow: 0 0 0 2px rgba(244,183,64,0.6),
+                      0 0 0 5px rgba(244,183,64,0.35),
+                      0 6px 14px rgba(0,0,0,0.5);
         }
         .aisw-marker--selected {
           transform: scale(1.55);
@@ -241,7 +255,7 @@ function buildMarkerEl(feature: ClusterFeature, onClick: () => void): HTMLElemen
     el.setAttribute("aria-label", `Cluster of ${count} companies. Click to zoom in.`);
   } else {
     const props = feature.properties as PointProps;
-    el.className = "aisw-marker";
+    el.className = props.fresh ? "aisw-marker aisw-marker--fresh" : "aisw-marker";
     el.style.background = props.hex;
     el.setAttribute("aria-label", `${props.name}. Click for details.`);
     el.title = props.name;

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -1,6 +1,13 @@
 // Mirrors apply_filters and FilterState in dashboard/components/filters.py.
 
 import type { Company } from "./types";
+import {
+  FRESHNESS_FUNDED,
+  FRESHNESS_VERIFIED,
+  isRecentlyFunded,
+  isRecentlyVerified,
+  type FreshnessFlag,
+} from "./freshness";
 
 export interface FilterState {
   sectors: string[];
@@ -9,6 +16,7 @@ export interface FilterState {
   foundedMin: number | null;
   foundedMax: number | null;
   nameQuery: string;
+  freshness: FreshnessFlag[];
 }
 
 export const EMPTY_FILTERS: FilterState = {
@@ -18,6 +26,7 @@ export const EMPTY_FILTERS: FilterState = {
   foundedMin: null,
   foundedMax: null,
   nameQuery: "",
+  freshness: [],
 };
 
 export function isFilterActive(state: FilterState): boolean {
@@ -27,7 +36,8 @@ export function isFilterActive(state: FilterState): boolean {
     state.countries.length > 0 ||
     state.foundedMin !== null ||
     state.foundedMax !== null ||
-    state.nameQuery.trim() !== ""
+    state.nameQuery.trim() !== "" ||
+    state.freshness.length > 0
   );
 }
 
@@ -57,6 +67,16 @@ export function applyFilters(companies: Company[], state: FilterState): Company[
   const q = state.nameQuery.trim().toLowerCase();
   if (q) {
     out = out.filter((c) => c.name.toLowerCase().includes(q));
+  }
+  if (state.freshness.length > 0) {
+    const now = new Date();
+    const wantVerified = state.freshness.includes(FRESHNESS_VERIFIED);
+    const wantFunded = state.freshness.includes(FRESHNESS_FUNDED);
+    out = out.filter((c) => {
+      const v = wantVerified && isRecentlyVerified(c, now);
+      const f = wantFunded && isRecentlyFunded(c, now);
+      return v || f;
+    });
   }
 
   return out;
@@ -96,6 +116,7 @@ export function filtersToParams(state: FilterState): URLSearchParams {
   if (state.foundedMin !== null) params.set("yearMin", String(state.foundedMin));
   if (state.foundedMax !== null) params.set("yearMax", String(state.foundedMax));
   if (state.nameQuery.trim() !== "") params.set("q", state.nameQuery.trim());
+  if (state.freshness.length > 0) params.set("fresh", state.freshness.join(","));
   return params;
 }
 
@@ -114,6 +135,9 @@ export function paramsToFilters(params: URLSearchParams): FilterState {
     const n = Number(raw);
     return Number.isFinite(n) ? n : null;
   };
+  const freshness = split("fresh").filter(
+    (v): v is FreshnessFlag => v === FRESHNESS_VERIFIED || v === FRESHNESS_FUNDED,
+  );
   return {
     sectors: split("sectors"),
     stages: split("stages"),
@@ -121,5 +145,6 @@ export function paramsToFilters(params: URLSearchParams): FilterState {
     foundedMin: numOrNull("yearMin"),
     foundedMax: numOrNull("yearMax"),
     nameQuery: params.get("q") ?? "",
+    freshness,
   };
 }

--- a/web/src/lib/freshness.ts
+++ b/web/src/lib/freshness.ts
@@ -1,0 +1,49 @@
+// Freshness signals derived from existing profile fields. Used by the
+// directory, map, and profile surfaces to highlight recently verified or
+// recently funded companies.
+
+import type { Company } from "./types";
+
+export const RECENTLY_VERIFIED_DAYS = 30;
+export const RECENTLY_FUNDED_DAYS = 90;
+
+export const FRESHNESS_VERIFIED = "verified";
+export const FRESHNESS_FUNDED = "funded";
+
+export type FreshnessFlag = typeof FRESHNESS_VERIFIED | typeof FRESHNESS_FUNDED;
+
+export const FRESHNESS_OPTIONS: { value: FreshnessFlag; label: string }[] = [
+  { value: FRESHNESS_VERIFIED, label: "Recently verified" },
+  { value: FRESHNESS_FUNDED, label: "Newly funded" },
+];
+
+function daysSince(iso: string | null, now: Date): number | null {
+  if (!iso) return null;
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return null;
+  const diffMs = now.getTime() - parsed;
+  if (diffMs < 0) return 0;
+  return diffMs / (1000 * 60 * 60 * 24);
+}
+
+export function isRecentlyVerified(c: Company, now: Date = new Date()): boolean {
+  const days = daysSince(c.profile_verified_at, now);
+  return days !== null && days <= RECENTLY_VERIFIED_DAYS;
+}
+
+export function isRecentlyFunded(c: Company, now: Date = new Date()): boolean {
+  const days = daysSince(c.total_raised_as_of, now);
+  return days !== null && days <= RECENTLY_FUNDED_DAYS;
+}
+
+export function verifiedAtMs(c: Company): number | null {
+  if (!c.profile_verified_at) return null;
+  const parsed = Date.parse(c.profile_verified_at);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function fundedAtMs(c: Company): number | null {
+  if (!c.total_raised_as_of) return null;
+  const parsed = Date.parse(c.total_raised_as_of);
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/web/src/lib/freshness.ts
+++ b/web/src/lib/freshness.ts
@@ -4,7 +4,7 @@
 
 import type { Company } from "./types";
 
-export const RECENTLY_VERIFIED_DAYS = 30;
+export const RECENTLY_VERIFIED_DAYS = 14;
 export const RECENTLY_FUNDED_DAYS = 90;
 
 export const FRESHNESS_VERIFIED = "verified";


### PR DESCRIPTION
## Summary

Surface freshness signals across the public dashboard so users can spot
recently verified and newly funded companies at a glance.

## Why

Issue #100: ~42 verified companies have rich profiles after the recent
deep-research pass, but the map and directory expose no freshness signal.
Users have no quick way to see which entries are fresh, which raised
recently, or which sectors are warm.

## Changes

- New `web/src/lib/freshness.ts` helpers (`isRecentlyVerified`,
  `isRecentlyFunded`) and a reusable `FreshnessBadges` component
  (icon + chip variants).
- Companies directory: badges next to every company name, on desktop
  rows and mobile cards. Filter bar gains a Freshness multiselect and a
  unified Sort dropdown that includes "Recently verified" and "Recently
  funded".
- Map: filter bar gains the same Freshness multiselect; markers for
  fresh companies render with an accent outline ring (sector colour
  unchanged); the company detail panel and the company profile header
  surface the same badges.
- Thresholds: 30 days for verified (`profile_verified_at`), 90 days for
  funded (`total_raised_as_of`). Uses existing fields only - no schema,
  API, or pipeline change.
- `PROJECT_PROGRESS.md` updated.

## Test plan

- [x] `pytest -q` passes (skipping pre-existing dashboard-extras tests
      that require Streamlit/folium; nothing in this PR touches Python)
- [x] `ruff check .` passes
- [x] `black --check .` passes
- [x] `npm run lint` (web) passes
- [x] `npm run build` (web) passes
- [ ] Manual smoke: visit `/companies` and `/map`, toggle the Freshness
      multiselect, exercise sort options, confirm badges appear and
      fresh markers ring.

## Multi-agent coordination

- [x] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [x] I am the assignee on the linked issue
- [x] Branch is named `<tool>/<issue-number>-<slug>`
- [x] Rebased on latest `main`

## Related issues

Closes #100
