### PR TITLE
[#108] [bug] Fix home hero rotating city punctuation

### DIFF
--- a/web/src/components/home/HomeContent.tsx
+++ b/web/src/components/home/HomeContent.tsx
@@ -58,13 +58,13 @@ export function HomeContent() {
           ANZ AI startup ecosystem
         </div>
 
-        <h1 className="mt-4 text-balance text-4xl font-semibold leading-[1.05] tracking-tight text-text sm:text-[64px] sm:leading-[1.02]">
-          A live map of AI companies
-          <br className="hidden sm:block" /> building from{" "}
+        <h1 className="mt-4 text-4xl font-semibold leading-[1.05] tracking-tight text-text sm:text-balance sm:text-[64px] sm:leading-[1.02]">
+          A live map of AI
+          <br className="sm:hidden" /> companies
+          <br /> building from{" "}
           <span className="text-accent">
-            <RotatingWord words={CITY_ROTATION} />
+            <RotatingWord words={CITY_ROTATION} suffix="." suffixClassName="text-text" />
           </span>
-          .
         </h1>
 
         <p className="mt-6 max-w-2xl text-balance text-lg leading-relaxed text-text-muted">

--- a/web/src/components/home/RotatingWord.tsx
+++ b/web/src/components/home/RotatingWord.tsx
@@ -5,9 +5,16 @@ import { type CSSProperties, useEffect, useMemo, useState } from "react";
 interface Props {
   words: string[];
   intervalMs?: number;
+  suffix?: string;
+  suffixClassName?: string;
 }
 
-export function RotatingWord({ words, intervalMs = 2400 }: Props) {
+export function RotatingWord({
+  words,
+  intervalMs = 2400,
+  suffix = "",
+  suffixClassName,
+}: Props) {
   const [index, setIndex] = useState(0);
   const longest = useMemo(
     () => Math.max(0, ...words.map((w) => w.length)),
@@ -45,9 +52,13 @@ export function RotatingWord({ words, intervalMs = 2400 }: Props) {
           }}
         >
           {word}
+          {suffix && <span className={suffixClassName}>{suffix}</span>}
         </span>
       ))}
-      <span className="invisible">{words[index]}</span>
+      <span className="invisible">
+        {words[index]}
+        {suffix}
+      </span>
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the home hero rotating-city punctuation so the full stop stays attached to the active city instead of sitting after the reserved animation width.

## Why

The rotating word reserves space for the longest city to avoid layout shift. The period was outside that component, so shorter cities left the punctuation visually detached. Mobile also needed explicit line breaks to avoid clipping the hero sentence.

## Changes

- Add optional suffix rendering to `RotatingWord` so punctuation animates with the active word.
- Render the home hero full stop as a non-accent suffix on the rotating city.
- Adjust mobile hero line breaks so the headline fits cleanly at 390px.

## Test plan

- [ ] `pytest -q` passes
- [x] `ruff check .` passes
- [x] `black --check .` passes
- [x] Manual smoke check: desktop and 390px mobile screenshots against `http://127.0.0.1:3008/`
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `PROJECT_PROGRESS.md` updated *if* this is a milestone (closes Now/Next issue, ships public feature, breaks something). Not a milestone, so unchanged.

`pytest -q` did not collect in the linked worktree venv because dashboard dependencies are missing: `streamlit` and `folium`.

## Multi-agent coordination

- [x] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [x] I am the assignee on the linked issue
- [x] Branch is named `<tool>/<issue-number>-<slug>`
- [x] Rebased on latest `main` (branched from `origin/main` during pre-flight)

## Screenshots

Validated locally at desktop and 390px mobile.

## Related issues

Closes #108
