### PR TITLE
feat(web): add basic viewer analytics

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -45,3 +45,7 @@ npm run lint
 - Admin mutations must stay server-side and authenticated.
 - Do not expose raw review artifacts, source extracts, or private operational
   details in UI copy.
+- Plausible Cloud tracks basic public pageviews for `aimap.cliftonfamily.co`.
+  The analytics component does not load during `next dev` or under `/admin`.
+  In Plausible Site Settings, add a Pages shield for `/admin*` as the
+  provider-side backstop.

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
+import { Analytics } from "@/components/Analytics";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -64,6 +65,7 @@ export default function RootLayout({
           {children}
         </main>
         <Footer />
+        <Analytics />
       </body>
     </html>
   );

--- a/web/src/components/Analytics.tsx
+++ b/web/src/components/Analytics.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Script from "next/script";
+import { usePathname } from "next/navigation";
+
+const PLAUSIBLE_DOMAIN = "aimap.cliftonfamily.co";
+const PLAUSIBLE_SCRIPT_SRC = "https://plausible.io/js/script.js";
+
+function isAdminPath(pathname: string): boolean {
+  return pathname === "/admin" || pathname.startsWith("/admin/");
+}
+
+export function Analytics() {
+  const pathname = usePathname();
+
+  if (process.env.NODE_ENV !== "production" || isAdminPath(pathname)) return null;
+
+  return (
+    <Script
+      id="plausible-analytics"
+      strategy="afterInteractive"
+      data-domain={PLAUSIBLE_DOMAIN}
+      src={PLAUSIBLE_SCRIPT_SRC}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- add basic Plausible Cloud pageview analytics to the Next.js app
- load analytics only in production and exclude direct admin routes
- document Plausible setup and provider-side `/admin*` shield

## Validation

- `cd web && npm run lint`
- `cd web && npm run build`
- production-build smoke confirmed Plausible appears on public pages and not on `/admin/login`
