### PR TITLE
fix(web): stop admin redirect loop

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -19,15 +19,6 @@ const nextConfig: NextConfig = {
       { source: "/_stcore/health", destination: "/api/health" },
     ];
   },
-  // Streamlit served the admin page at /Admin (derived from 90_Admin.py).
-  // Next.js routes are case-sensitive. Redirect anyone with the old URL
-  // bookmarked or in muscle memory to the canonical lowercase route.
-  async redirects() {
-    return [
-      { source: "/Admin", destination: "/admin", permanent: false },
-      { source: "/Admin/:path*", destination: "/admin/:path*", permanent: false },
-    ];
-  },
 };
 
 export default nextConfig;

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,0 +1,16 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  if (pathname !== "/Admin" && !pathname.startsWith("/Admin/")) {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = `/admin${pathname.slice("/Admin".length)}`;
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: ["/Admin", "/Admin/:path*"],
+};


### PR DESCRIPTION
## Summary

- remove the case-insensitive `/Admin` redirect from `next.config.ts`
- add a case-aware Next proxy for legacy `/Admin` URLs
- restore lowercase `/admin` and `/admin/login` behavior

## Validation

- `cd web && npm run lint`
- `cd web && npm run build`
- local production smoke:
  - `/admin/login` returns 200
  - `/Admin/login` redirects once to `/admin/login`
  - `/admin` redirects unauthenticated users to `/admin/login`
