### PR TITLE
fix(web): proxy plausible through first party routes

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -17,6 +17,8 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       { source: "/_stcore/health", destination: "/api/health" },
+      { source: "/_asset/map.js", destination: "https://plausible.io/js/script.js" },
+      { source: "/_asset/event", destination: "https://plausible.io/api/event" },
     ];
   },
 };

--- a/web/src/components/Analytics.tsx
+++ b/web/src/components/Analytics.tsx
@@ -4,7 +4,8 @@ import Script from "next/script";
 import { usePathname } from "next/navigation";
 
 const PLAUSIBLE_DOMAIN = "aimap.cliftonfamily.co";
-const PLAUSIBLE_SCRIPT_SRC = "https://plausible.io/js/script.js";
+const PLAUSIBLE_SCRIPT_SRC = "/_asset/map.js";
+const PLAUSIBLE_EVENT_ENDPOINT = "/_asset/event";
 
 function isAdminPath(pathname: string): boolean {
   return pathname === "/admin" || pathname.startsWith("/admin/");
@@ -20,6 +21,7 @@ export function Analytics() {
       id="plausible-analytics"
       strategy="afterInteractive"
       data-domain={PLAUSIBLE_DOMAIN}
+      data-api={PLAUSIBLE_EVENT_ENDPOINT}
       src={PLAUSIBLE_SCRIPT_SRC}
     />
   );


### PR DESCRIPTION
## Summary

- proxy Plausible script and event ingestion through first-party app routes
- update the analytics component to load `/_asset/map.js`
- send Plausible events to `/_asset/event` via `data-api`

## Why

Direct `plausible.io` requests were not producing recorded events after manual testing. First-party proxying is Plausible's recommended path when browser privacy tooling blocks third-party analytics requests.

## Validation

- `cd web && npm run lint`
- `cd web && npm run build`
- local production smoke confirmed `/_asset/map.js` serves the Plausible script
- local HTML references `/_asset/map.js` and `/_asset/event`
