### PR TITLE
fix(web): update plausible install script

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -17,8 +17,10 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       { source: "/_stcore/health", destination: "/api/health" },
-      { source: "/_asset/map.js", destination: "https://plausible.io/js/script.js" },
-      { source: "/_asset/event", destination: "https://plausible.io/api/event" },
+      {
+        source: "/map-data/script.js",
+        destination: "https://plausible.io/js/pa-y14so16JDPotlwE9pZNzK.js",
+      },
     ];
   },
 };

--- a/web/src/app/map-data/event/route.ts
+++ b/web/src/app/map-data/event/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PLAUSIBLE_EVENT_ENDPOINT = "https://plausible.io/api/event";
+
+function forwardedHeaders(request: NextRequest): HeadersInit {
+  const headers = new Headers({
+    "Content-Type": request.headers.get("content-type") ?? "text/plain",
+  });
+
+  for (const name of [
+    "user-agent",
+    "x-forwarded-for",
+    "x-real-ip",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+  ]) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+
+  return headers;
+}
+
+export async function POST(request: NextRequest) {
+  const response = await fetch(PLAUSIBLE_EVENT_ENDPOINT, {
+    method: "POST",
+    headers: forwardedHeaders(request),
+    body: await request.text(),
+    cache: "no-store",
+  });
+
+  return new NextResponse(await response.text(), {
+    status: response.status,
+    headers: {
+      "Content-Type": response.headers.get("content-type") ?? "text/plain",
+      "X-Plausible-Dropped": response.headers.get("x-plausible-dropped") ?? "0",
+    },
+  });
+}

--- a/web/src/components/Analytics.tsx
+++ b/web/src/components/Analytics.tsx
@@ -3,9 +3,8 @@
 import Script from "next/script";
 import { usePathname } from "next/navigation";
 
-const PLAUSIBLE_DOMAIN = "aimap.cliftonfamily.co";
-const PLAUSIBLE_SCRIPT_SRC = "/_asset/map.js";
-const PLAUSIBLE_EVENT_ENDPOINT = "/_asset/event";
+const PLAUSIBLE_SCRIPT_SRC = "/map-data/script.js";
+const PLAUSIBLE_EVENT_ENDPOINT = "/map-data/event";
 
 function isAdminPath(pathname: string): boolean {
   return pathname === "/admin" || pathname.startsWith("/admin/");
@@ -17,12 +16,19 @@ export function Analytics() {
   if (process.env.NODE_ENV !== "production" || isAdminPath(pathname)) return null;
 
   return (
-    <Script
-      id="plausible-analytics"
-      strategy="afterInteractive"
-      data-domain={PLAUSIBLE_DOMAIN}
-      data-api={PLAUSIBLE_EVENT_ENDPOINT}
-      src={PLAUSIBLE_SCRIPT_SRC}
-    />
+    <>
+      <Script
+        id="plausible-init"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)};
+plausible.init=plausible.init||function(i){plausible.o=i||{}};
+plausible.init({ endpoint: "${PLAUSIBLE_EVENT_ENDPOINT}" });
+          `.trim(),
+        }}
+      />
+      <Script id="plausible-analytics" strategy="afterInteractive" src={PLAUSIBLE_SCRIPT_SRC} />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- switch the first-party Plausible proxy to the site-specific script Plausible expects
- forward analytics events through a Next route at /map-data/event
- keep admin pages excluded through the existing Analytics guard

## Tests
- cd web && npm run lint
- cd web && npm run build
- local production smoke: /map-data/script.js serves Plausible script, /map-data/event returns 202 ok