### PR TITLE
[#118] [feature] expand ANZ news ingestion sources

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -15,6 +15,14 @@ contact details out of this file. Routine fixes belong in PR bodies.
 
 ## Recent Milestones
 
+### 2026-05-01: Expanded ANZ News Ingestion
+
+- Added reviewed ANZ startup feeds for InnovationAus Startups, Startup News AU,
+  and NZ Entrepreneur to improve live news coverage.
+- Kept the ingestion path unchanged: RSS fetches feed the existing relevance,
+  company-linking, and pending-review gates.
+- No schema, dashboard UI, or LLM budget change.
+
 ### 2026-04-30: Mobile Public Dashboard Optimisation
 
 - Added mobile-first navigation and responsive filter sheets for the public

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -13,6 +13,18 @@ operational map of every endpoint, query, or reviewed extract.
 | Investor and ecosystem publications | Cross-check funding, stage, and company metadata. | Reviewed imports only. Raw extracts stay local. |
 | Company-owned pages | Confirm website, location, summary, and operating context. | Store concise facts, not copied page text. |
 
+## Reviewed News Sources
+
+The weekly pipeline includes these reviewed ANZ startup publication feeds:
+
+| Slug | Feed | Rationale |
+|---|---|---|
+| `startup_daily_au` | Startup Daily RSS | Broad Australian and New Zealand startup coverage. |
+| `smartcompany_startups` | SmartCompany StartupSmart RSS | Australian startup funding, launches, and operator news. |
+| `innovationaus_startups` | InnovationAus Startups RSS | Australian technology, deep tech, policy, and startup coverage. |
+| `startupnews_au` | Startup News RSS | Western Australian startup ecosystem coverage. |
+| `nzentrepreneur` | NZ Entrepreneur RSS | New Zealand founder, startup, and ecosystem coverage. |
+
 ## Inclusion Rules
 
 - Only use sources that are publicly accessible and permitted by their access

--- a/src/ai_sector_watch/pipeline/weekly.py
+++ b/src/ai_sector_watch/pipeline/weekly.py
@@ -63,6 +63,9 @@ def default_sources() -> list[SourceBase]:
     return [
         rss.startup_daily_au(),
         rss.smartcompany_startups(),
+        rss.innovationaus_startups(),
+        rss.startupnews_au(),
+        rss.nzentrepreneur(),
         sitemap.capital_brief(),
         sitemap.airtree_open_source_vc(),
         sitemap.blackbird_blog(),

--- a/src/ai_sector_watch/sources/rss.py
+++ b/src/ai_sector_watch/sources/rss.py
@@ -93,5 +93,20 @@ def smartcompany_startups() -> RssSource:
     )
 
 
+def innovationaus_startups() -> RssSource:
+    return RssSource(
+        "innovationaus_startups",
+        "https://www.innovationaus.com/category/startups/feed/",
+    )
+
+
+def startupnews_au() -> RssSource:
+    return RssSource("startupnews_au", "https://startupnews.com.au/feed/")
+
+
+def nzentrepreneur() -> RssSource:
+    return RssSource("nzentrepreneur", "https://nzentrepreneur.co.nz/feed/")
+
+
 def crunchbase_ai() -> RssSource:
     return RssSource("crunchbase_ai", "https://news.crunchbase.com/sections/ai/feed/")

--- a/tests/test_rss_sources.py
+++ b/tests/test_rss_sources.py
@@ -21,7 +21,13 @@ from ai_sector_watch.sources.huggingface_papers import (
     HuggingFacePapers,
     parse_huggingface_payload,
 )
-from ai_sector_watch.sources.rss import RssSource, parse_feed_bytes
+from ai_sector_watch.sources.rss import (
+    RssSource,
+    innovationaus_startups,
+    nzentrepreneur,
+    parse_feed_bytes,
+    startupnews_au,
+)
 from ai_sector_watch.sources.sitemap import (
     airtree_open_source_vc,
     blackbird_blog,
@@ -75,6 +81,19 @@ def test_rss_source_raises_on_http_error(monkeypatch) -> None:
     source = RssSource("bad", "https://example.com/bad")
     with pytest.raises(httpx.HTTPStatusError):
         source.fetch()
+
+
+def test_anz_startup_feed_factories_use_reviewed_urls() -> None:
+    sources = [innovationaus_startups(), startupnews_au(), nzentrepreneur()]
+    assert [(s.slug, s.kind, s.url) for s in sources] == [
+        (
+            "innovationaus_startups",
+            "news",
+            "https://www.innovationaus.com/category/startups/feed/",
+        ),
+        ("startupnews_au", "news", "https://startupnews.com.au/feed/"),
+        ("nzentrepreneur", "news", "https://nzentrepreneur.co.nz/feed/"),
+    ]
 
 
 def test_parse_google_news_sitemap_bytes_extracts_items() -> None:


### PR DESCRIPTION
## Summary

Adds three reviewed ANZ startup RSS feeds to the weekly ingestion pipeline so the live news feed has broader durable coverage.

## Why

The live `/news` page currently has a small article set, mostly from Startup Daily and SmartCompany. These additional ANZ-focused feeds give the existing relevance and review gates more local startup signal.

## Changes

- Added RSS factories for InnovationAus Startups, Startup News AU, and NZ Entrepreneur.
- Registered the feeds in `default_sources()`.
- Documented the reviewed news source set and added fixture-level factory tests.
- Recorded the public feed expansion in `PROJECT_PROGRESS.md`.

## Test plan

- [x] `.venv/bin/pytest -q` passes
- [x] `.venv/bin/ruff check .` passes
- [x] `.venv/bin/black --check .` passes
- [x] Manual smoke check: fetched 3 current items from each new RSS feed without DB writes
- [x] `PROJECT_PROGRESS.md` updated *if* this is a milestone (closes Now/Next issue, ships public feature, breaks something). Otherwise leave alone.

## Multi-agent coordination

- [x] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [x] I am the assignee on the linked issue
- [x] Branch is named `<tool>/<issue-number>-<slug>`
- [x] Rebased on latest `main` (no merge conflicts with other in-flight PRs)

## Screenshots

No dashboard UI change.

## Related issues

Closes #118
