### PR TITLE
[#121] [bug] remove blocked InnovationAus weekly source

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -17,8 +17,8 @@ contact details out of this file. Routine fixes belong in PR bodies.
 
 ### 2026-05-01: Expanded ANZ News Ingestion
 
-- Added reviewed ANZ startup feeds for InnovationAus Startups, Startup News AU,
-  and NZ Entrepreneur to improve live news coverage.
+- Added reviewed ANZ startup feeds for Startup News AU and NZ Entrepreneur to
+  improve live news coverage.
 - Kept the ingestion path unchanged: RSS fetches feed the existing relevance,
   company-linking, and pending-review gates.
 - No schema, dashboard UI, or LLM budget change.

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -21,7 +21,6 @@ The weekly pipeline includes these reviewed ANZ startup publication feeds:
 |---|---|---|
 | `startup_daily_au` | Startup Daily RSS | Broad Australian and New Zealand startup coverage. |
 | `smartcompany_startups` | SmartCompany StartupSmart RSS | Australian startup funding, launches, and operator news. |
-| `innovationaus_startups` | InnovationAus Startups RSS | Australian technology, deep tech, policy, and startup coverage. |
 | `startupnews_au` | Startup News RSS | Western Australian startup ecosystem coverage. |
 | `nzentrepreneur` | NZ Entrepreneur RSS | New Zealand founder, startup, and ecosystem coverage. |
 

--- a/src/ai_sector_watch/pipeline/weekly.py
+++ b/src/ai_sector_watch/pipeline/weekly.py
@@ -63,7 +63,6 @@ def default_sources() -> list[SourceBase]:
     return [
         rss.startup_daily_au(),
         rss.smartcompany_startups(),
-        rss.innovationaus_startups(),
         rss.startupnews_au(),
         rss.nzentrepreneur(),
         sitemap.capital_brief(),

--- a/src/ai_sector_watch/sources/rss.py
+++ b/src/ai_sector_watch/sources/rss.py
@@ -93,13 +93,6 @@ def smartcompany_startups() -> RssSource:
     )
 
 
-def innovationaus_startups() -> RssSource:
-    return RssSource(
-        "innovationaus_startups",
-        "https://www.innovationaus.com/category/startups/feed/",
-    )
-
-
 def startupnews_au() -> RssSource:
     return RssSource("startupnews_au", "https://startupnews.com.au/feed/")
 

--- a/tests/test_rss_sources.py
+++ b/tests/test_rss_sources.py
@@ -23,7 +23,6 @@ from ai_sector_watch.sources.huggingface_papers import (
 )
 from ai_sector_watch.sources.rss import (
     RssSource,
-    innovationaus_startups,
     nzentrepreneur,
     parse_feed_bytes,
     startupnews_au,
@@ -84,13 +83,8 @@ def test_rss_source_raises_on_http_error(monkeypatch) -> None:
 
 
 def test_anz_startup_feed_factories_use_reviewed_urls() -> None:
-    sources = [innovationaus_startups(), startupnews_au(), nzentrepreneur()]
+    sources = [startupnews_au(), nzentrepreneur()]
     assert [(s.slug, s.kind, s.url) for s in sources] == [
-        (
-            "innovationaus_startups",
-            "news",
-            "https://www.innovationaus.com/category/startups/feed/",
-        ),
         ("startupnews_au", "news", "https://startupnews.com.au/feed/"),
         ("nzentrepreneur", "news", "https://nzentrepreneur.co.nz/feed/"),
     ]


### PR DESCRIPTION
## Summary

Removes the InnovationAus RSS feed from active weekly ingestion after the production GitHub Actions runner returned 403.

## Why

The first bounded weekly run after PR #119 completed as partial because `innovationaus_startups` was blocked in Actions. Default sources should be reachable from the production runner.

## Changes

- Removed `innovationaus_startups` from `default_sources()`.
- Removed the blocked feed factory, docs entry, and test expectation.
- Updated the progress entry to list the two active new feeds.

## Test plan

- [x] `.venv/bin/pytest tests/test_rss_sources.py tests/test_pipeline_integration.py -q` passes
- [x] `.venv/bin/pytest -q` passes
- [x] `.venv/bin/ruff check .` passes
- [x] `.venv/bin/black --check .` passes
- [x] Manual smoke check: production weekly run `25197878189` showed `startupnews_au` visible on live `/api/news`, while `innovationaus_startups` failed with 403
- [x] `PROJECT_PROGRESS.md` updated *if* this is a milestone (closes Now/Next issue, ships public feature, breaks something). Otherwise leave alone.

## Multi-agent coordination

- [x] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [x] I am the assignee on the linked issue
- [x] Branch is named `<tool>/<issue-number>-<slug>`
- [x] Rebased on latest `main` (no merge conflicts with other in-flight PRs)

## Screenshots

No dashboard UI change.

## Related issues

Closes #121
