### PR TITLE
fix(review): address automated feedback

### DIFF
--- a/scripts/apply_cut_through_import.py
+++ b/scripts/apply_cut_through_import.py
@@ -129,7 +129,7 @@ def _currency_is_explicit_usd(currency_raw: str | None) -> bool:
     if not currency_raw:
         return False
     raw = currency_raw.upper().replace(" ", "")
-    return "USD" in raw or "US$" in raw or raw.startswith("US$")
+    return raw == "USD" or raw.startswith("USD") or raw.startswith("US$")
 
 
 def _parse_date(value: Any) -> date | None:

--- a/scripts/audit_company_locations.py
+++ b/scripts/audit_company_locations.py
@@ -49,6 +49,7 @@ from ai_sector_watch.storage import supabase_db  # noqa: E402
 LOGGER = logging.getLogger("audit_company_locations")
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "docs" / "data-audits"
 HIGH_CONFIDENCE_THRESHOLD = 0.75
+SUPPORTED_COUNTRIES = frozenset({"AU", "NZ"})
 COORD_TOLERANCE = 0.000001
 
 LOCATION_SYSTEM_PROMPT = (
@@ -216,6 +217,10 @@ def _normalise_country(value: str | None) -> str | None:
     return aliases.get(key, key)
 
 
+def _is_supported_country(value: str | None) -> bool:
+    return value in SUPPORTED_COUNTRIES
+
+
 def _coords_match(
     *,
     current_lat: Any,
@@ -346,8 +351,13 @@ def build_location_audit(
         or _is_empty(company.get("lon"))
     )
     has_recommendation = not _is_empty(recommended_city) and not _is_empty(recommended_country)
+    supported_recommendation = _is_supported_country(recommended_country)
     high_confidence = facts.confidence >= HIGH_CONFIDENCE_THRESHOLD
-    proposed_geo = geocode_city(recommended_city, jitter_seed=name) if recommended_city else None
+    proposed_geo = (
+        geocode_city(recommended_city, jitter_seed=name)
+        if recommended_city and supported_recommendation
+        else None
+    )
     proposed_lat = proposed_geo.lat if proposed_geo else None
     proposed_lon = proposed_geo.lon if proposed_geo else None
 
@@ -356,7 +366,7 @@ def build_location_audit(
 
     if not enriched or not has_recommendation:
         action = ACTION_MISSING_LOCATION if not has_current_location else ACTION_MANUAL_REVIEW
-    elif proposed_geo is None:
+    elif not supported_recommendation or proposed_geo is None:
         action = ACTION_UNSUPPORTED_CITY
     elif not has_current_location:
         action = ACTION_MISSING_LOCATION

--- a/scripts/extract_cut_through_report.py
+++ b/scripts/extract_cut_through_report.py
@@ -321,7 +321,7 @@ def _currency_is_explicit_usd(currency_raw: str | None) -> bool:
     if not currency_raw:
         return False
     raw = currency_raw.upper().replace(" ", "")
-    return "USD" in raw or "US$" in raw or raw.startswith("US$")
+    return raw == "USD" or raw.startswith("USD") or raw.startswith("US$")
 
 
 def _trim_markdown(markdown: str, max_chars: int) -> str:

--- a/scripts/generate_verification_prompts.py
+++ b/scripts/generate_verification_prompts.py
@@ -235,6 +235,9 @@ def bucket_by_group(companies: list[dict[str, Any]]) -> dict[str, list[dict[str,
             if sector is None:
                 continue
             groups_touched.add(sector.group)
+        if not groups_touched:
+            buckets.setdefault("unknown_sector", []).append(company)
+            continue
         for group in groups_touched:
             existing = buckets.setdefault(group, [])
             if not any(str(c.get("id")) == str(company.get("id")) for c in existing):

--- a/scripts/parse_verification_responses.py
+++ b/scripts/parse_verification_responses.py
@@ -573,6 +573,12 @@ def run_parse(
     counts: Counter[str] = Counter(entry.verdict for entry in merged)
     summary.by_verdict = dict(counts)
 
+    if summary.files_failed:
+        summary.errors.append(
+            f"{len(summary.files_failed)} response file or entry parse failure(s); "
+            "see files_failed"
+        )
+
     timestamp = timestamp or datetime.now(UTC)
     stem = timestamp.strftime("%Y%m%dT%H%M%SZ")
 

--- a/tests/test_audit_company_locations.py
+++ b/tests/test_audit_company_locations.py
@@ -130,6 +130,19 @@ def test_unsupported_extracted_city_requires_review_without_update() -> None:
     assert finding.recommended_city == "Byron Bay"
 
 
+def test_non_anz_country_with_known_city_requires_review_without_update() -> None:
+    finding, update = audit_locations.build_location_audit(
+        _company(city="Sydney", country="AU"),
+        _facts(hq_city="Hamilton", hq_country="CA"),
+        enriched=True,
+    )
+
+    assert finding.action == audit_locations.ACTION_UNSUPPORTED_CITY
+    assert update is None
+    assert finding.recommended_city == "Hamilton"
+    assert finding.recommended_country == "CA"
+
+
 def test_low_confidence_mismatch_requires_manual_review() -> None:
     finding, update = audit_locations.build_location_audit(
         _company(city="Melbourne"),

--- a/tests/test_cut_through_import.py
+++ b/tests/test_cut_through_import.py
@@ -247,6 +247,35 @@ def test_apply_validation_rejects_bare_dollar_amount_usd(tmp_path: Path) -> None
     assert "amount_usd is allowed only when currency_raw is explicit USD" in summary.errors[0]
 
 
+def test_aus_dollar_marker_is_not_treated_as_explicit_usd(tmp_path: Path) -> None:
+    assert not extract_report._currency_is_explicit_usd("AUS$5M")
+    assert not apply_import._currency_is_explicit_usd("AUS$5M")
+
+    row = extract_report.ExtractedFundingRow(
+        company_name="AUS Dollar Co",
+        country="AU",
+        is_ai_related=True,
+        stage="seed",
+        amount_usd="5000000",
+        currency_raw="AUS$5M",
+        confidence=0.8,
+    )
+    report = discover_reports.CutThroughReport(
+        title="Cut Through Quarterly 1Q 2026",
+        publication_date="2026-04-28",
+        report_url="https://www.cutthrough.com/insights/cut-through-quarterly-1q-2026",
+        pdf_url=None,
+        pdf_download_url=None,
+        quarter=1,
+        year=2026,
+        summary=None,
+    )
+
+    rendered = extract_report._normalise_funding_event(row, report=report)
+    assert rendered["amount_usd"] is None
+    assert "amount_usd cleared" in rendered["notes"]
+
+
 def test_apply_dry_run_counts_reviewed_actions(tmp_path: Path) -> None:
     path = tmp_path / "payload.json"
     payload = _review_payload()

--- a/tests/test_generate_verification_prompts.py
+++ b/tests/test_generate_verification_prompts.py
@@ -51,6 +51,14 @@ def test_bucket_by_group_dedupes_within_a_group() -> None:
     assert [c["name"] for c in buckets["infra"]] == ["CrossGroup"]
 
 
+def test_bucket_by_group_preserves_unknown_sector_tags() -> None:
+    companies = [_company("1", "UnknownTagCo", sector_tags=["future_unknown"])]
+
+    buckets = g.bucket_by_group(companies)
+
+    assert [c["name"] for c in buckets["unknown_sector"]] == ["UnknownTagCo"]
+
+
 def test_render_prompt_contains_company_record_and_enums() -> None:
     template = (REPO_ROOT / "prompts" / "verify_sector.md").read_text(encoding="utf-8")
     companies = [

--- a/tests/test_parse_verification_responses.py
+++ b/tests/test_parse_verification_responses.py
@@ -167,6 +167,31 @@ def test_run_parse_writes_apply_and_flags_artifacts(tmp_path: Path) -> None:
     assert flags_payload["companies"][0]["id"] == "co-2"
 
 
+def test_run_parse_reports_failed_response_files_as_errors(tmp_path: Path) -> None:
+    responses = tmp_path / "responses"
+    responses.mkdir()
+    (responses / "valid.md").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "co-1",
+                    "name": "GoodCo",
+                    "verdict": "confirm",
+                    "updates": {},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (responses / "broken.md").write_text("not json", encoding="utf-8")
+
+    summary = p.run_parse(input_dir=tmp_path, write=False)
+
+    assert summary.entries_seen == 1
+    assert summary.files_failed
+    assert summary.errors
+
+
 def test_run_parse_merges_multi_sector_entries(tmp_path: Path) -> None:
     """Same company id appearing in two responses gets merged."""
     responses = tmp_path / "responses"

--- a/web/src/app/api/news/route.ts
+++ b/web/src/app/api/news/route.ts
@@ -10,7 +10,8 @@ export const revalidate = 0;
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const limitParam = Number(url.searchParams.get("limit") ?? 100);
-  const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 500) : 100;
+  const normalisedLimit = Number.isFinite(limitParam) ? Math.trunc(limitParam) : 100;
+  const limit = Math.min(Math.max(normalisedLimit, 1), 500);
 
   try {
     const items = await listRecentNews(limit);

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({
           Skip to main content
         </a>
         <Header />
-        <main id="main-content" className="flex-1 flex flex-col">
+        <main id="main-content" tabIndex={-1} className="flex-1 flex flex-col">
           {children}
         </main>
         <Footer />

--- a/web/src/components/Analytics.tsx
+++ b/web/src/components/Analytics.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import Script from "next/script";
 import { usePathname } from "next/navigation";
 
@@ -10,8 +11,38 @@ function isAdminPath(pathname: string): boolean {
   return pathname === "/admin" || pathname.startsWith("/admin/");
 }
 
+type PlausibleFunction = {
+  (eventName: string, options?: { url?: string }): void;
+  q?: unknown[][];
+  init?: (options?: Record<string, unknown>) => void;
+  o?: Record<string, unknown>;
+};
+
+declare global {
+  interface Window {
+    plausible?: PlausibleFunction;
+  }
+}
+
+function queuePageview(): void {
+  window.plausible =
+    window.plausible ||
+    ((...args: unknown[]) => {
+      const plausible = window.plausible;
+      if (!plausible) return;
+      plausible.q = plausible.q || [];
+      plausible.q.push(args);
+    });
+  window.plausible("pageview", { url: window.location.href });
+}
+
 export function Analytics() {
   const pathname = usePathname();
+  const shouldTrack = process.env.NODE_ENV === "production" && !isAdminPath(pathname);
+
+  useEffect(() => {
+    if (shouldTrack) queuePageview();
+  }, [shouldTrack, pathname]);
 
   if (process.env.NODE_ENV !== "production" || isAdminPath(pathname)) return null;
 
@@ -24,7 +55,7 @@ export function Analytics() {
           __html: `
 window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)};
 plausible.init=plausible.init||function(i){plausible.o=i||{}};
-plausible.init({ endpoint: "${PLAUSIBLE_EVENT_ENDPOINT}" });
+plausible.init({ endpoint: "${PLAUSIBLE_EVENT_ENDPOINT}", autoCapturePageviews: false });
           `.trim(),
         }}
       />

--- a/web/src/components/map/Map.tsx
+++ b/web/src/components/map/Map.tsx
@@ -118,7 +118,7 @@ export function Map({ companies, selectedId, onSelect }: MapProps) {
   useEffect(() => {
     Object.entries(markersRef.current).forEach(([id, marker]) => {
       const el = marker.getElement();
-      if (id === selectedId) {
+      if (selectedId !== null && id === `point-${selectedId}`) {
         el.classList.add("aisw-marker--selected");
       } else {
         el.classList.remove("aisw-marker--selected");

--- a/web/src/components/news/NewsContent.tsx
+++ b/web/src/components/news/NewsContent.tsx
@@ -13,6 +13,14 @@ interface SpendSummary {
   run_count: number;
 }
 
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
 export function NewsContent() {
   const [items, setItems] = useState<NewsItem[] | null>(null);
   const [companies, setCompanies] = useState<Company[]>([]);
@@ -22,9 +30,9 @@ export function NewsContent() {
   useEffect(() => {
     let cancelled = false;
     Promise.all([
-      fetch("/api/news?limit=100").then((r) => r.json()),
-      fetch("/api/companies").then((r) => r.json()),
-      fetch("/api/spend-summary").then((r) => r.json()),
+      fetchJson<{ items?: NewsItem[] }>("/api/news?limit=100"),
+      fetchJson<{ companies?: Company[] }>("/api/companies"),
+      fetchJson<{ summary?: SpendSummary | null }>("/api/spend-summary"),
     ])
       .then(([news, companiesRes, spendRes]) => {
         if (cancelled) return;

--- a/web/src/lib/slug.ts
+++ b/web/src/lib/slug.ts
@@ -15,9 +15,14 @@ export function buildSlugMap<T extends { id: string; name: string }>(
   items: T[],
 ): Map<string, T> {
   const map = new Map<string, T>();
+  const baseCounts = new Map<string, number>();
   for (const item of items) {
     const base = slugify(item.name);
-    if (!map.has(base)) {
+    baseCounts.set(base, (baseCounts.get(base) ?? 0) + 1);
+  }
+  for (const item of items) {
+    const base = slugify(item.name);
+    if ((baseCounts.get(base) ?? 0) === 1) {
       map.set(base, item);
       continue;
     }


### PR DESCRIPTION
## Summary

Addresses the remaining actionable automated review findings that still reproduced on current main.

## Changes

- Keep public company/news/frontend routes resilient: verified-only companies remain enforced, API limit parsing is integer-safe, non-OK news fetches surface errors, duplicate-name slugs are deterministic, selected map markers highlight correctly, and skip-link focus lands on main content.
- Switch Plausible to manual pageviews so admin routes are not tracked after client-side navigation.
- Harden Cut Through USD detection, verification prompt/response handling, and location audit country guards.
- Add focused regression tests for the Python paths.

## Test plan

- [x] PYTHONPATH=src /Users/samuelclifton/Documents/Projects/AI-Sector-Watch/.venv/bin/python -m pytest tests/test_cut_through_import.py tests/test_audit_company_locations.py tests/test_generate_verification_prompts.py tests/test_parse_verification_responses.py -q
- [x] /Users/samuelclifton/Documents/Projects/AI-Sector-Watch/.venv/bin/ruff check .
- [x] /Users/samuelclifton/Documents/Projects/AI-Sector-Watch/.venv/bin/black . --check
- [x] PYTHONPATH=src /Users/samuelclifton/Documents/Projects/AI-Sector-Watch-116-feature-audit-public-company-summaries/.venv/bin/python -m pytest -q
- [x] npm run lint
- [x] npm run build

## Notes

Full pytest against the main worktree venv was missing legacy dashboard extras; the full run above used the existing dashboard-capable venv from the old issue worktree. No live Supabase writes, LLM calls, DNS changes, or Azure changes were run.