### PR TITLE
[#125] Fix research JSON fallback in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN addgroup --system --gid 1001 node-app \
 COPY --from=build --chown=node-app:node-app /app/.next/standalone ./
 COPY --from=build --chown=node-app:node-app /app/.next/static ./.next/static
 COPY --from=build --chown=node-app:node-app /app/public ./public
+COPY --chown=node-app:node-app data/research_briefs ./data/research_briefs
 
 USER node-app
 

--- a/web/src/lib/research-server.ts
+++ b/web/src/lib/research-server.ts
@@ -52,7 +52,21 @@ async function listResearchRunsFromDb(limit: number): Promise<ResearchBriefRun[]
 }
 
 async function listResearchRunsFromJson(limit: number): Promise<ResearchBriefRun[]> {
-  const directory = path.resolve(process.cwd(), "..", "data", "research_briefs");
+  const directories = [
+    path.resolve(process.cwd(), "data", "research_briefs"),
+    path.resolve(process.cwd(), "..", "data", "research_briefs"),
+  ];
+  for (const directory of directories) {
+    const runs = await listResearchRunsFromDirectory(directory, limit);
+    if (runs.length > 0) return runs;
+  }
+  return [];
+}
+
+async function listResearchRunsFromDirectory(
+  directory: string,
+  limit: number,
+): Promise<ResearchBriefRun[]> {
   try {
     const entries = await fs.readdir(directory, { withFileTypes: true });
     const files = entries


### PR DESCRIPTION
## Summary
- Copy committed `data/research_briefs` into the Next.js standalone container.
- Make the research JSON fallback search both local dev and runtime container paths.

## Verification
- `.venv/bin/pytest -q tests/test_web_research_static.py`
- `.venv/bin/ruff check . && .venv/bin/black --check .`
- `cd web && npm run lint && npm run build`

Closes #125
