### PR TITLE
[#128] Schedule research briefs twice weekly

### DIFF
--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -1,0 +1,57 @@
+name: research-brief
+
+on:
+  schedule:
+    # 00:00 UTC is 10:00 / 11:00 Tuesday and Friday in Australia/Sydney.
+    - cron: "0 0 * * 2,5"
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Run date as YYYY-MM-DD in Australia/Sydney. Defaults to today."
+        required: false
+      limit:
+        description: "Items per source"
+        required: false
+        default: "25"
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+      PIPELINE_LOG_LEVEL: INFO
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Verify setup
+        run: python scripts/verify_setup.py --apply-schema
+
+      - name: Run research brief
+        run: |
+          DATE="${{ github.event.inputs.date }}"
+          if [ -z "$DATE" ]; then
+            DATE="$(TZ=Australia/Sydney date +%F)"
+          fi
+          LIMIT="${{ github.event.inputs.limit || '25' }}"
+          python scripts/run_research_brief.py \
+            --date "$DATE" \
+            --limit "$LIMIT" \
+            --scheduled-window \
+            --timezone Australia/Sydney \
+            --no-json \
+            --write-db

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -43,43 +43,46 @@ gh run watch
 Use small limits first. Do not run unbounded source, enrichment, or LLM jobs
 from a development environment.
 
-## Daily Research Briefs
+## Research Briefs
 
 The public `/research` page reads stored research brief runs from
 `research_brief_runs`. It does not fetch sources or call a model during page
 rendering. If Supabase is unavailable in local development, the web app falls
 back to JSON files under `data/research_briefs/`.
 
+`.github/workflows/research.yml` runs the research brief on Australian Tuesdays
+and Fridays. The scheduled run date is calculated in `Australia/Sydney`; each
+run uses `--scheduled-window` so Tuesday covers the prior Friday-to-Tuesday
+gap and Friday covers the prior Tuesday-to-Friday gap. The workflow writes
+directly to Supabase and does not commit generated JSON.
+
 Manual local JSON run:
 
 ```bash
-python scripts/run_research_brief.py --date YYYY-MM-DD
+python scripts/run_research_brief.py --date YYYY-MM-DD --scheduled-window
 ```
 
 Manual database write run:
 
 ```bash
-op run --env-file=.env.local -- python scripts/run_research_brief.py --date YYYY-MM-DD --write-db
+op run --env-file=.env.local -- python scripts/run_research_brief.py --date YYYY-MM-DD --scheduled-window --write-db
 ```
 
 Bound test run:
 
 ```bash
-python scripts/run_research_brief.py --date YYYY-MM-DD --limit 5 --dry-run
+python scripts/run_research_brief.py --date YYYY-MM-DD --limit 5 --scheduled-window --dry-run
 ```
 
-The existing daily Codex automation should run the script after it finishes any
-brief generation step:
+Production dispatch:
 
 ```bash
-op run --env-file=.env.local -- python scripts/run_research_brief.py --date "$(date -u +%F)" --write-db
+gh workflow run research.yml -f date=YYYY-MM-DD -f limit=25
+gh run watch
 ```
 
-If moving this into GitHub Actions instead, schedule a daily cron that installs
-the Python package, applies the idempotent schema through
-`scripts/verify_setup.py --apply-schema`, then runs the same `--write-db`
-command with `SUPABASE_DB_URL` from repository secrets. Keep source limits
-bounded until the run history looks stable.
+Use small limits first when manually dispatching. Do not add social media,
+newsletters, or general tech media to this workflow without source review.
 
 ## GitHub Actions Secret Check
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -26,7 +26,7 @@ The weekly pipeline includes these reviewed ANZ startup publication feeds:
 
 ## Reviewed Research Sources
 
-The daily research brief uses primary research sources and stores only concise
+The twice-weekly research brief uses primary research sources and stores only concise
 metadata, links, and generated notes:
 
 | Slug | Feed | Rationale |

--- a/scripts/run_research_brief.py
+++ b/scripts/run_research_brief.py
@@ -8,6 +8,7 @@ import logging
 import sys
 from datetime import UTC, date, datetime, time, timedelta
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
@@ -24,6 +25,7 @@ from ai_sector_watch.sources.base import RawItem  # noqa: E402
 from ai_sector_watch.storage import supabase_db  # noqa: E402
 
 LOGGER = logging.getLogger(__name__)
+SCHEDULED_RUN_WEEKDAYS = (1, 4)  # Tuesday, Friday.
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -39,7 +41,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--hours",
         type=int,
         default=36,
-        help="Lookback window in hours ending at the end of the run date.",
+        help="Lookback window in hours ending at the end of the run date. Ignored with --scheduled-window.",
+    )
+    parser.add_argument(
+        "--scheduled-window",
+        action="store_true",
+        help="Use the Tuesday/Friday Australia/Sydney window covering days since the prior scheduled run.",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="Australia/Sydney",
+        help="IANA timezone used for --scheduled-window. Defaults to Australia/Sydney.",
     )
     parser.add_argument(
         "--limit",
@@ -79,8 +91,12 @@ def main(argv: list[str] | None = None) -> int:
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(levelname)s %(message)s",
     )
-    window_end = datetime.combine(args.date + timedelta(days=1), time.min, tzinfo=UTC)
-    window_start = window_end - timedelta(hours=args.hours)
+    window_start, window_end = research_window(
+        run_date=args.date,
+        hours=args.hours,
+        scheduled_window=args.scheduled_window,
+        timezone_name=args.timezone,
+    )
     raw_items, source_errors = fetch_research_items(limit=args.limit)
     run = build_research_brief_run(
         raw_items=raw_items,
@@ -135,6 +151,38 @@ def fetch_research_items(*, limit: int) -> tuple[list[RawItem], list[str]]:
             LOGGER.warning(message)
             errors.append(message)
     return items, errors
+
+
+def research_window(
+    *,
+    run_date: date,
+    hours: int,
+    scheduled_window: bool,
+    timezone_name: str,
+) -> tuple[datetime, datetime]:
+    """Return the UTC source window for a research brief run."""
+    if not scheduled_window:
+        window_end = datetime.combine(run_date + timedelta(days=1), time.min, tzinfo=UTC)
+        return window_end - timedelta(hours=hours), window_end
+
+    try:
+        timezone = ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"unknown timezone: {timezone_name}") from exc
+
+    previous_run_date = previous_scheduled_run_date(run_date)
+    local_start = datetime.combine(previous_run_date, time.min, tzinfo=timezone)
+    local_end = datetime.combine(run_date + timedelta(days=1), time.min, tzinfo=timezone)
+    return local_start.astimezone(UTC), local_end.astimezone(UTC)
+
+
+def previous_scheduled_run_date(run_date: date) -> date:
+    """Return the previous Tuesday or Friday before run_date."""
+    for days_back in range(1, 8):
+        candidate = run_date - timedelta(days=days_back)
+        if candidate.weekday() in SCHEDULED_RUN_WEEKDAYS:
+            return candidate
+    raise RuntimeError("no scheduled weekday found in previous seven days")
 
 
 def _parse_date(value: str) -> date:

--- a/src/ai_sector_watch/research/briefs.py
+++ b/src/ai_sector_watch/research/briefs.py
@@ -93,7 +93,7 @@ class ResearchBriefSections:
 
 @dataclass(frozen=True)
 class ResearchBriefRun:
-    """Database and JSON shape for one daily research brief run."""
+    """Database and JSON shape for one research brief run."""
 
     id: str
     run_date: str
@@ -333,7 +333,7 @@ def _summary(*, run_date: date, window_count: int, ranked_count: int) -> str:
     if ranked_count == 0:
         return (
             f"No primary-source frontier AI items were selected for {run_date.isoformat()} "
-            "after the daily filter pass."
+            "after the filter pass."
         )
     return (
         f"Reviewed {window_count} primary-source research items for "

--- a/tests/test_research_briefs.py
+++ b/tests/test_research_briefs.py
@@ -11,6 +11,7 @@ from ai_sector_watch.research.briefs import (
     write_research_run_json,
 )
 from ai_sector_watch.sources.base import RawItem
+from scripts.run_research_brief import previous_scheduled_run_date, research_window
 
 
 def test_build_research_brief_run_shapes_primary_source_items() -> None:
@@ -55,3 +56,41 @@ def test_write_research_run_json_round_trips(tmp_path) -> None:
     assert path.name == "2026-05-02.json"
     assert payload["sections"]["skipped_noise_note"]
     assert payload["sections"]["top_items"] == []
+
+
+def test_research_window_for_australian_tuesday_covers_prior_friday_gap() -> None:
+    start, end = research_window(
+        run_date=date(2026, 5, 5),
+        hours=36,
+        scheduled_window=True,
+        timezone_name="Australia/Sydney",
+    )
+
+    assert previous_scheduled_run_date(date(2026, 5, 5)) == date(2026, 5, 1)
+    assert start == datetime(2026, 4, 30, 14, tzinfo=UTC)
+    assert end == datetime(2026, 5, 5, 14, tzinfo=UTC)
+
+
+def test_research_window_for_australian_friday_covers_prior_tuesday_gap() -> None:
+    start, end = research_window(
+        run_date=date(2026, 5, 8),
+        hours=36,
+        scheduled_window=True,
+        timezone_name="Australia/Sydney",
+    )
+
+    assert previous_scheduled_run_date(date(2026, 5, 8)) == date(2026, 5, 5)
+    assert start == datetime(2026, 5, 4, 14, tzinfo=UTC)
+    assert end == datetime(2026, 5, 8, 14, tzinfo=UTC)
+
+
+def test_research_window_preserves_legacy_hour_lookback() -> None:
+    start, end = research_window(
+        run_date=date(2026, 5, 2),
+        hours=36,
+        scheduled_window=False,
+        timezone_name="Australia/Sydney",
+    )
+
+    assert start == datetime(2026, 5, 1, 12, tzinfo=UTC)
+    assert end == datetime(2026, 5, 3, tzinfo=UTC)

--- a/tests/test_research_workflow_static.py
+++ b/tests/test_research_workflow_static.py
@@ -1,0 +1,18 @@
+"""Static checks for the research brief workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_research_workflow_runs_tuesday_and_friday_with_scheduled_window() -> None:
+    workflow = (ROOT / ".github/workflows/research.yml").read_text()
+
+    assert 'cron: "0 0 * * 2,5"' in workflow
+    assert "TZ=Australia/Sydney date +%F" in workflow
+    assert "--scheduled-window" in workflow
+    assert "--timezone Australia/Sydney" in workflow
+    assert "--write-db" in workflow
+    assert "--no-json" in workflow


### PR DESCRIPTION
## Summary
- Add a `research.yml` workflow scheduled for 00:00 UTC on Tuesday and Friday, which lands on Australian Tuesday and Friday.
- Add `--scheduled-window` to `scripts/run_research_brief.py` so Tuesday covers the prior Friday gap and Friday covers the prior Tuesday gap in `Australia/Sydney`.
- Update operations/source docs and add schedule-window/static workflow tests.

## Verification
- `.venv/bin/pytest -q`
- `.venv/bin/ruff check . && .venv/bin/black --check .`
- `cd web && npm run lint && npm run build`
- `.venv/bin/python scripts/run_research_brief.py --date 2026-05-05 --scheduled-window --limit 1 --dry-run`

Closes #128
