### PR TITLE
[#130] [feature] add LinkedIn link to About page

### DIFF
--- a/dashboard/pages/0_About.py
+++ b/dashboard/pages/0_About.py
@@ -16,6 +16,7 @@ from dashboard.components.theme import render_page_chrome  # noqa: E402
 
 ARCHITECTURE_PATH = REPO_ROOT / "dashboard" / "static" / "architecture.svg"
 GITHUB_REPO_URL = "https://github.com/SCClifton/ai-sector-watch"
+LINKEDIN_URL = "https://www.linkedin.com/in/sam-c-clifton/"
 ISSUES_URL = f"{GITHUB_REPO_URL}/issues"
 
 
@@ -95,8 +96,9 @@ def main() -> None:
         "repository contains the public source code, schema, taxonomy, and public-safe "
         "operating notes."
     )
-    link_cols = st.columns([1, 3])
+    link_cols = st.columns([1, 1, 2])
     link_cols[0].link_button("GitHub repository", GITHUB_REPO_URL, type="primary")
+    link_cols[1].link_button("LinkedIn profile", LINKEDIN_URL)
 
     render_footer()
 

--- a/web/src/app/about/page.tsx
+++ b/web/src/app/about/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowUpRight, Github, MessageCircle } from "lucide-react";
+import { ArrowUpRight, Github, Linkedin, MessageCircle } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "About",
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
 };
 
 const GITHUB_URL = "https://github.com/SCClifton/ai-sector-watch";
+const LINKEDIN_URL = "https://www.linkedin.com/in/sam-c-clifton/";
 const ISSUES_URL = `${GITHUB_URL}/issues`;
 
 export default function AboutPage() {
@@ -99,6 +100,15 @@ export default function AboutPage() {
           >
             <Github className="h-3.5 w-3.5" />
             GitHub repository
+          </Link>
+          <Link
+            href={LINKEDIN_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex min-h-11 items-center gap-1.5 rounded-md border border-border-strong bg-surface px-4 py-2 text-[13px] font-semibold text-text transition-colors hover:border-accent hover:text-accent"
+          >
+            <Linkedin className="h-3.5 w-3.5" />
+            LinkedIn profile
           </Link>
         </div>
       </Section>


### PR DESCRIPTION
## Summary

Adds Sam Clifton LinkedIn profile link beside the GitHub link at the bottom of the About page.

## Why

The project About page should expose both the source repository and maintainer profile.

## Changes

- Added LinkedIn URL and button to the public Next.js About page.
- Mirrored the link in the legacy Streamlit About page during migration.

## Test plan

- [x] `/tmp/aisw-130-venv/bin/pytest -q` passes, with live Supabase tests skipped because `SUPABASE_DB_URL` is unset
- [x] `.venv/bin/ruff check .` passes
- [x] `.venv/bin/black --check .` passes
- [x] `npm run lint` passes in `web/`
- [x] `npm run build` passes in `web/`
- [x] Manual smoke check: rendered `http://127.0.0.1:3130/about` and confirmed `LinkedIn profile` links to `https://www.linkedin.com/in/sam-c-clifton/` next to `GitHub repository`
- [x] `PROJECT_PROGRESS.md` not updated because this is not a milestone

## Multi-agent coordination

- [x] I followed the pre-flight in [docs/multi-agent-workflow.md](docs/multi-agent-workflow.md)
- [x] I am the assignee on the linked issue
- [x] Branch is named `codex/130-feature-add-linkedin-link-to-about-page`
- [x] Branch started from latest `origin/main` via `scripts/start_issue.sh`

## Screenshots

Not attached. Verified rendered HTML for the About page.

## Related issues

Closes #130
