### PR TITLE
[codex] Validate infrastructure economics in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Validate infrastructure economics
+        working-directory: web
+        run: |
+          npm ci
+          npm run validate:infra
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,15 +17,30 @@ jobs:
           python-version: "3.12"
           cache: pip
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
       - name: Install
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dashboard,dev]"
 
+      - name: Install web dependencies
+        working-directory: web
+        run: npm ci
+
       - name: Lint
         run: |
           ruff check .
           black --check .
+
+      - name: Validate infrastructure economics
+        working-directory: web
+        run: npm run validate:infra
 
       - name: Test
         run: pytest -q


### PR DESCRIPTION
## What changed

Adds the infrastructure economics validation script to automated checks:

- `pytest.yml` now installs Node/web dependencies and runs `npm run validate:infra` on PRs and pushes to `main`.
- `deploy.yml` now runs `npm ci` and `npm run validate:infra` before building and pushing the production container.

## Why

The infrastructure dashboard depends on structured stack, workload, scenario, project, source, and probability assumptions. This makes broken formula or data edits fail before merge and before deployment.

## Validation

- `npm run validate:infra`
- `git diff --check`

Live UI pass after the previous deployment found no remaining page-level overflow across public routes. The only issue found, mobile selector overflow on `/infrastructure`, was already fixed and deployed in PR #132.