### PR TITLE
[codex] Opt GitHub Actions into Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ permissions:
 env:
   AZURE_RESOURCE_GROUP: ai-sector-watch
   AZURE_WEBAPP_NAME: ai-sector-watch
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   IMAGE_NAME: ai-sector-watch
   REGISTRY: ghcr.io
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/research.yml
+++ b/.github/workflows/research.yml
@@ -17,6 +17,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -15,6 +15,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

Sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` across the GitHub Actions workflows.

## Why

The latest deployment surfaced GitHub's Node 20 action runtime deprecation warning. Opting in now tests the workflows against the runtime GitHub will force from June 2026.

## Validation

- `npm run validate:infra`
- `git diff --check`